### PR TITLE
Fix project dependency

### DIFF
--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'io.grpc:grpc-stub:1.23.0'
     implementation 'com.google.protobuf:protobuf-java:3.0.0'
 
-    implementation project(':common')
+    implementation project(':sql')
 }
 
 spotbugsMain.enabled = false

--- a/modules/sql/build.gradle
+++ b/modules/sql/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.0.0'
     implementation 'org.msgpack:msgpack-core:0.8.19'
 
-    implementation project(':common')
+    api project(':common')
 }
 
 spotbugsMain.enabled = false


### PR DESCRIPTION
最新のmasterをプロジェクトルートからビルドすると、プロジェクトの依存関係が不足しているためにコンパイルエラーが発生します。
確認したところ、現時点ではビルド定義に以下2点の問題があるように思ったので、以下2点を修正しています。

- 1 [ ipc -> sql ] への依存関係が定義されていない
- 2 [ ipc -> common ]内のprotobuf生成クラスへの依存関係が定義されていない

1 については依存関係を追加すればよいだけだと思います（単なる定義漏れ？）
2 については、protocol bufferへの依存をどのように考えているかという話で、
- 2-a commonから直接依存を解決する
- 2-b sqlの推移的依存関係として依存を解決する
のどちらかになると思います。ソースコードを見る限り、ResultSetImplの実装などから 2-b のように意図していると思われたので、一応そのように修正しています。

もしプロジェクト依存関係の定義上の問題ではなく、実装側に問題があるようでしたらコードのほうを修正し、このPRはマージせずクローズしてください。