### PR TITLE
Enable to publish maven local repository

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -5,6 +5,9 @@ plugins {
     id 'com.github.spotbugs'
 }
 
+group = 'com.nautilus_technologies.tsubakuro'
+version = '0.0.1'
+
 repositories {
     mavenCentral()
 }

--- a/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
@@ -4,3 +4,18 @@ plugins {
 
     id 'tsubakuro.java-conventions'
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = project.name
+
+            from components.java
+
+            artifact sourcesJar {
+                classifier = 'sources'
+                extension  = 'jar'
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/tsubakuro.jni-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.jni-library-conventions.gradle
@@ -10,6 +10,9 @@ def nativeTestRootDir = "$project.projectDir/src/test/native"
 def nativeTestBuildDir = "${nativeTestRootDir}/build"
 def nativeTestIncludeDir = "${nativeTestRootDir}/include"
 
+def nativeLibDir = "$project.buildDir/native"
+
+
 task cmakeConfigure {
     inputs.files(fileTree(nativeRootDir) {
         exclude 'build/**'
@@ -67,6 +70,23 @@ task cmakeBuild {
     }
 }
 
+task nativeLib {
+    inputs.files(nativeBuildDir)
+    .withPropertyName('nativeBuildDir')
+
+    outputs.file("${nativeLibDir}/*.so")
+    .withPropertyName('nativeLibFile')
+
+    doLast {
+        copy {
+            from "${nativeBuildDir}/src"
+            into "${nativeLibDir}"
+            include '*.so'
+        }
+    }
+}
+
+
 task cmakeTestBuild {
     inputs.files(fileTree(nativeTestRootDir) {
         exclude 'build/**'
@@ -86,7 +106,7 @@ task cmakeTestBuild {
     }
 }
 
-assemble.dependsOn cmakeBuild
+assemble.dependsOn nativeLib
 test.dependsOn cmakeTestBuild
 
 cmakeConfigure.dependsOn compileJava
@@ -94,6 +114,8 @@ cmakeTestConfigure.dependsOn compileTestJava
 
 cmakeBuild.dependsOn cmakeConfigure
 cmakeTestBuild.dependsOn cmakeTestConfigure
+
+nativeLib.dependsOn cmakeBuild
 
 clean {
     delete += "$nativeBuildDir"

--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'tsubakuro.java-library-conventions'
     id 'tsubakuro.jni-library-conventions'
 }
 
@@ -6,4 +7,19 @@ dependencies {
     implementation 'org.msgpack:msgpack-core:0.8.24'
 
     implementation project(':common')
+}
+
+publishing {
+    publications {
+        mavenNative(MavenPublication) {
+            artifactId = "libwire"
+            artifact "${buildDir}/native/libwire.so"
+        }
+    }
+}
+
+tasks.withType(AbstractPublishToMaven) { task ->
+    if (task.name == 'publishMavenNativePublicationToMavenLocal') {
+        task.dependsOn nativeLib
+    }
 }


### PR DESCRIPTION
GradleのMaven Publish Pluginを使ってMaven Repositoryにdeployするビルド定義を追加します。

リモートへのホスト先が決まっていないので、とりあえずはローカルリポジトリにのみdeploy可能な定義のみを追加しています。
リモートへのdeployを行うには追加の設定が必要になるのですが、
このPull Requestの内容が結合テストに必要になるのでいったんこの状態でPull Requestします。
