### PR TITLE
Fix warning using `AbstractArchiveTask.extension`

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
@@ -14,7 +14,7 @@ publishing {
 
             artifact sourcesJar {
                 classifier = 'sources'
-                extension  = 'jar'
+                archiveExtension  = 'jar'
             }
         }
     }


### PR DESCRIPTION
#33 で `The AbstractArchiveTask.extension property has been deprecated. ...` といった非推奨のタスクプロパティを使用している旨の警告がでるようになってしまったので、その修正です。