### PR TITLE
add Explain request/response for proto messages

### DIFF
--- a/modules/common/src/main/protos/request.proto
+++ b/modules/common/src/main/protos/request.proto
@@ -97,6 +97,11 @@ message DisposePreparedStatement {
 message Disconnect {
 }
 
+/* For explain prepared sql. */
+message Explain {
+  common.PreparedStatement prepared_statement_handle = 1;
+  ParameterSet parameters = 2;
+}
 
 /* For request message to the SQL service. */
 message Request {
@@ -112,5 +117,6 @@ message Request {
     Rollback rollback = 9;
     DisposePreparedStatement dispose_prepared_statement = 10;
     Disconnect disconnect = 11;
+    Explain explain = 12;
   }
 }

--- a/modules/common/src/main/protos/response.proto
+++ b/modules/common/src/main/protos/response.proto
@@ -58,6 +58,13 @@ message ExecuteQuery {
   schema.RecordMeta record_meta = 2;
 }
 
+/* For response to Explain. */
+message Explain {
+  oneof result {
+    string output = 1;  /* The result output string of the explain. */
+    Error error = 2;
+  }
+}
 
 /* For response message from the SQL service. */
 message Response {
@@ -66,5 +73,6 @@ message Response {
     Begin begin = 2;
     Prepare prepare = 3;
     ExecuteQuery execute_query = 4;
+    Explain explain = 5;
   }
 }


### PR DESCRIPTION
Explain用のリクエストメッセージと結果を受け取るresponseの追加です。

APIを単純にするため、prepared statementのみを受け取るようにしています。(SQL textそのままは不可で一旦prepareする必要がある)