### PR TITLE
Fix implicit_dependency warnings on :proto:sourcesJar

### DIFF
--- a/modules/proto/build.gradle
+++ b/modules/proto/build.gradle
@@ -29,3 +29,7 @@ protobuf {
 
 checkstyleMain.enabled = false
 spotbugsMain.enabled = false
+
+tasks.withType(com.google.protobuf.gradle.GenerateProtoTask){
+    sourcesJar.dependsOn(generateProto)
+}


### PR DESCRIPTION
`:proto:sourcesJar` タスクで implicit_dependency 関連の警告が出ていたのを修正しました
