### PR TITLE
Enable CheckStyle rule `UnusedImports`

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -37,10 +37,7 @@
     <!-- <module name="AvoidStarImport"> <property name="allowStaticMemberImports" value="true"/> </module> -->
     <module name="IllegalImport"/>
     <module name="RedundantImport"/>
-    <module name="UnusedImports">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
+    <module name="UnusedImports"/>
     <module name="MethodLength">
       <property name="severity" value="error"/>
     </module>


### PR DESCRIPTION
CheckStyleの「未使用インポート」のチェックを有効にします。
未使用インポートを放置するとIDEのProblem欄がこれで埋め尽くされてしまうので修正したほうがよいと思います。