### PR TITLE
Add Gradle task `allJavadoc` and `clientApiJavadoc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ Build and deploy only the java libraries into Maven Local Repository.
 ```
 ./gradlew PublishMavenJavaPublicationToMavenLocal -x ipc:cmakeBuild
 ```
+
+### generate all(aggregated) Javadoc
+Generate Javadoc for whole Tsubakuro classes in directory `${ProjectTopDirectory}/build/docs/javadoc-all`.
+```
+cd ${ProjectTopDirectory}
+./gradlew allJavadoc
+```
+
+Generated in directory `${ProjectTopDirectory}/build/docs/javadoc-all`
+
+### generate Javadoc for client API
+Generate Javadoc for Tsubakuro client API in directory `${ProjectTopDirectory}/build/docs/javadoc-client-api`.
+
+```
+cd ${ProjectTopDirectory}
+./gradlew clientApiJavadoc
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'tsubakuro.javadocs'
+}

--- a/buildSrc/src/main/groovy/tsubakuro.javadocs.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.javadocs.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+}
+
+def clientApiProjects = [
+    ":common",
+    ":session",
+    ":connector"
+]
+
+tasks.register('clientApiJavadoc', Javadoc)
+tasks.named('clientApiJavadoc') {
+    source clientApiProjects.collect { project(it).sourceSets.main.allJava }
+    classpath = files(clientApiProjects.collect { project(it).sourceSets.main.compileClasspath })
+    destinationDir = file("${buildDir}/docs/javadoc-client-api")
+    title = "Tsubakuro Client API JavaDoc"
+    options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+}
+
+tasks.register('allJavadoc', Javadoc)
+tasks.named('allJavadoc') {
+    source project.allprojects.collect { it.sourceSets.main.allJava }
+    classpath = files(project.allprojects.collect { it.sourceSets.main.compileClasspath })
+    destinationDir = file("${buildDir}/docs/javadoc-all")
+    title = "Tsubakuro All JavaDoc"
+    options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
+}
+


### PR DESCRIPTION
以下のGradleタスクを追加します。
* `allJavadoc` : Tsubakuro全体の集約されたJavaDocを生成
* `clientApiJavadoc` : TsubakuroのクライアントAPI向けJavaDocを生成

使い方はREADME.mdに追記しました。

`clientApiJavadoc` のほうは、とりあえずプロジェクト `common` , `session` , `connector` のJavaDoc集約して生成しています。含めるプロジェクトは今回追加したファイル `tsubakuro.javadocs.gradle` の配列変数 `clientApiProjects` で変更できます。
もうすこし決め細かいフィルタもかけられますが、いったんここまでで問題なければマージおねがいします。