### PR TITLE
Fix README - install only java libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Build and deploy the java and native libraries into Maven Local Repository.
 ### install only java libraries
 Build and deploy only the java libraries into Maven Local Repository.
 ```
-./gradlew PublishMavenJavaPublicationToMavenLocal -x ipc:cmakeBuild
+./gradlew PublishMavenJavaPublicationToMavenLocal
 ```
 
 ### generate all(aggregated) Javadoc


### PR DESCRIPTION
Gradleタスクの実行方法で一部不要なオプション指定があったので修正しました。