### PR TITLE
Introduce `Connector.create(URI)`.

### DIFF
--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+
     api 'org.msgpack:msgpack-core:0.8.24'
     api 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'org.slf4j:slf4j-nop:1.7.32'

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/Connector.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/Connector.java
@@ -1,17 +1,57 @@
 package com.nautilus_technologies.tsubakuro.channel.common.connection;
 
-import java.util.concurrent.Future;
 import java.io.IOException;
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+import javax.annotation.Nonnull;
+
 import com.nautilus_technologies.tsubakuro.channel.common.sql.SessionWire;
 
 /**
  * Connector type.
  */
 public interface Connector {
+
     /**
-     * Connect to the sql service
+     * Creates a new connector for the end-point string.
+     * @param endpoint the end-point URI
+     * @return the corresponded connector
+     * @throws IllegalArgumentException if the end-point string is not a valid URI
+     * @throws NoSuchElementException if there is no suitable connector implementation for the URI
+     */
+    static Connector create(@Nonnull String endpoint) {
+        Objects.nonNull(endpoint);
+        return ConnectorHelper.create(URI.create(endpoint));
+    }
+
+    /**
+     * Creates a new connector for the end-point URI.
+     * @param endpoint the end-point URI
+     * @return the corresponded connector
+     * @throws NoSuchElementException if there is no suitable connector implementation for the URI
+     */
+    static Connector create(@Nonnull URI endpoint) {
+        Objects.nonNull(endpoint);
+        return ConnectorHelper.create(endpoint);
+    }
+
+    /**
+     * Establishes a connection to the Tsurugi server.
      * @return future session wire
      * @throws IOException connection error
      */
-    Future<SessionWire> connect() throws IOException;
+    default Future<SessionWire> connect() throws IOException {
+        return connect(NullCredential.INSTANCE);
+    }
+
+    /**
+     * Establishes a connection to the Tsurugi server.
+     * @param credential the connection credential
+     * @return future session wire
+     * @throws IOException connection error
+     */
+    Future<SessionWire> connect(@Nonnull Credential credential) throws IOException;
 }

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorFactory.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorFactory.java
@@ -1,0 +1,20 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import java.net.URI;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A factory of {@link Connector} implementation.
+ */
+public interface ConnectorFactory {
+
+    /**
+     * Creates a new connector if the end-point URI is suitable for this.
+     * @param endpoint the target end-point URI
+     * @return a connector which provides a connection to the target end-point
+     */
+    Optional<? extends Connector> tryCreate(@Nonnull URI endpoint);
+
+}

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorHelper.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorHelper.java
@@ -1,0 +1,34 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import java.net.URI;
+import java.text.MessageFormat;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.ServiceLoader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ConnectorHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectorHelper.class);
+
+    static Connector create(URI endpoint) {
+        Objects.requireNonNull(endpoint);
+        LOG.trace("creating connector: {}", endpoint); //$NON-NLS-1$
+        for (var factory : ServiceLoader.load(ConnectorFactory.class)) {
+            var connectorOpt = factory.tryCreate(endpoint);
+            if (connectorOpt.isPresent()) {
+                LOG.trace("found ConnectorFactory: {} - {}", factory, endpoint); //$NON-NLS-1$
+                return connectorOpt.get();
+            }
+        }
+        throw new NoSuchElementException(MessageFormat.format(
+                "suitable connector is not found: {0}",
+                endpoint));
+    }
+
+    private ConnectorHelper() {
+        throw new AssertionError();
+    }
+}

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/Credential.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/Credential.java
@@ -1,0 +1,10 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+/**
+ * Represents credential information.
+ * This interface provides nothing; please see the implementation classes.
+ * @see NullCredential
+ */
+public interface Credential {
+    // no special members
+}

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/NullCredential.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/NullCredential.java
@@ -1,0 +1,12 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+/**
+ * Represents an empty credential.
+ */
+public enum NullCredential implements Credential {
+
+    /**
+     * The singleton instance.
+     */
+    INSTANCE,
+}

--- a/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/UsernamePasswordCredential.java
+++ b/modules/common/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/UsernamePasswordCredential.java
@@ -1,0 +1,52 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A credential by user name and password.
+ */
+public class UsernamePasswordCredential implements Credential {
+
+    private final String name;
+
+    private final String password;
+
+    /**
+     * Creates a new instance.
+     * @param name the user name
+     * @param password the password
+     */
+    public UsernamePasswordCredential(@Nonnull String name, @Nullable String password) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        this.password = password;
+    }
+
+    /**
+     * Returns the user name.
+     * @return the user name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the password.
+     * @return the password
+     */
+    public Optional<String> getPassword() {
+        return Optional.of(password);
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format(
+                "UsernamePasswordCredential(name={0})",
+                name);
+    }
+}

--- a/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorTest.java
+++ b/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorTest.java
@@ -1,0 +1,25 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+
+class ConnectorTest {
+
+    @Test
+    void create() {
+        var connector = Connector.create("testing:example");
+        assertTrue(connector instanceof TestingConnector);
+
+        var tc = (TestingConnector) connector;
+        assertEquals(URI.create("testing:example"), tc.endpoint);
+
+        assertThrows(IllegalArgumentException.class, () -> Connector.create(" "));
+        assertThrows(NoSuchElementException.class, () -> Connector.create("invalid:invalid"));
+    }
+}

--- a/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/TestingConnector.java
+++ b/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/TestingConnector.java
@@ -1,0 +1,21 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.Future;
+
+import com.nautilus_technologies.tsubakuro.channel.common.sql.SessionWire;
+
+class TestingConnector implements Connector {
+
+    final URI endpoint;
+
+    TestingConnector(URI endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public Future<SessionWire> connect(Credential credential) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/TestingConnectorFactory.java
+++ b/modules/common/src/test/java/com/nautilus_technologies/tsubakuro/channel/common/connection/TestingConnectorFactory.java
@@ -1,0 +1,20 @@
+package com.nautilus_technologies.tsubakuro.channel.common.connection;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ConnectorFactory} for testing.
+ */
+public class TestingConnectorFactory implements ConnectorFactory {
+
+    @Override
+    public Optional<Connector> tryCreate(URI endpoint) {
+        if (Objects.equals(endpoint.getScheme(), "testing")) {
+            return Optional.of(new TestingConnector(endpoint));
+        }
+        return Optional.empty();
+    }
+
+}

--- a/modules/common/src/test/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
+++ b/modules/common/src/test/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
@@ -1,0 +1,1 @@
+com.nautilus_technologies.tsubakuro.channel.common.connection.TestingConnectorFactory

--- a/modules/connector/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorImpl.java
+++ b/modules/connector/src/main/java/com/nautilus_technologies/tsubakuro/channel/common/connection/ConnectorImpl.java
@@ -11,32 +11,34 @@ import com.nautilus_technologies.tsubakuro.channel.ipc.connection.IpcConnectorIm
  */
 public final class ConnectorImpl implements Connector {
     private Connector connector;
-    
-    public ConnectorImpl(String name) {
-	if (name.contains(":")) {
-	    String[] elements = name.split(":");
 
-	    int port;
-	    if (elements.length < 2) {
-		port = StreamConnectorImpl.DEFAULT_PORT;
-	    } else {
-		if (elements.length > 2) {
-		    System.err.println("`:` shoud be one in the connection name");
-		}
-		try {
-		    port = Integer.parseInt(elements[1]);
-		} catch (NumberFormatException e) {
-		    System.err.println(elements[1] + " is not a number, use default port (" + StreamConnectorImpl.DEFAULT_PORT + ")");
-		    port = StreamConnectorImpl.DEFAULT_PORT;
-		}
-	    }
-	    this.connector = new StreamConnectorImpl(elements[0], port);
-	} else {	
-	    this.connector = new IpcConnectorImpl(name);
-	}
+    public ConnectorImpl(String name) {
+        if (name.contains(":")) {
+            String[] elements = name.split(":");
+
+            int port;
+            if (elements.length < 2) {
+                port = StreamConnectorImpl.DEFAULT_PORT;
+            } else {
+                if (elements.length > 2) {
+                    System.err.println("`:` shoud be one in the connection name");
+                }
+                try {
+                    port = Integer.parseInt(elements[1]);
+                } catch (NumberFormatException e) {
+                    System.err.println(elements[1] + " is not a number, use default port ("
+                            + StreamConnectorImpl.DEFAULT_PORT + ")");
+                    port = StreamConnectorImpl.DEFAULT_PORT;
+                }
+            }
+            this.connector = new StreamConnectorImpl(elements[0], port);
+        } else {
+            this.connector = new IpcConnectorImpl(name);
+        }
     }
 
-    public Future<SessionWire> connect() throws IOException {
-	return connector.connect();
+    @Override
+    public Future<SessionWire> connect(Credential credential) throws IOException {
+        return connector.connect(credential);
     }
 }

--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+
     api 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.msgpack:msgpack-core:0.8.24'
     testImplementation 'org.slf4j:slf4j-nop:1.7.32'

--- a/modules/ipc/src/main/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorFactory.java
+++ b/modules/ipc/src/main/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorFactory.java
@@ -1,0 +1,46 @@
+package com.nautilus_technologies.tsubakuro.channel.ipc.connection;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory;
+
+/**
+ * An implementation of {@link ConnectorFactory} which provides instances of {@link IpcConnectorImpl}.
+ *
+ * This factory can handle {@code ipc:<channel-name>} style end-point URI, and will ignore other parts of it.
+ */
+public class IpcConnectorFactory implements ConnectorFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IpcConnectorFactory.class);
+
+    private static final String SCHEME = "ipc"; //$NON-NLS-1$
+
+    @Override
+    public Optional<IpcConnectorImpl> tryCreate(@Nonnull URI endpoint) {
+        Objects.requireNonNull(endpoint);
+
+        LOG.trace("testing whether or not URI is suitable for {} connector: '{}'", SCHEME, endpoint); //$NON-NLS-1$
+
+
+        if (!Objects.equals(endpoint.getScheme(), SCHEME)) {
+            LOG.trace("URI is not suitable for {} connector: '{}' (invalid scheme)", SCHEME, endpoint); //$NON-NLS-1$
+            return Optional.empty();
+        }
+
+        var body = endpoint.getSchemeSpecificPart();
+        if (Objects.isNull(body) || body.isEmpty()) {
+            LOG.trace("URI is not suitable for {} connector: '{}' (invalid channel name)", SCHEME, endpoint); //$NON-NLS-1$
+            return Optional.empty();
+        }
+
+        LOG.debug("recognized endpoit URI scheme='{}', name='{}'", SCHEME, body); //$NON-NLS-1$
+        return Optional.of(new IpcConnectorImpl(body));
+    }
+}

--- a/modules/ipc/src/main/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorImpl.java
+++ b/modules/ipc/src/main/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorImpl.java
@@ -4,8 +4,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.io.IOException;
+
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.nautilus_technologies.tsubakuro.channel.common.connection.Connector;
+import com.nautilus_technologies.tsubakuro.channel.common.connection.Credential;
 import com.nautilus_technologies.tsubakuro.channel.common.sql.SessionWire;
 import com.nautilus_technologies.tsubakuro.channel.ipc.sql.SessionWireImpl;
 
@@ -13,6 +16,9 @@ import com.nautilus_technologies.tsubakuro.channel.ipc.sql.SessionWireImpl;
  * IpcConnectorImpl type.
  */
 public final class IpcConnectorImpl implements Connector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IpcConnectorImpl.class);
+
     private static native long getConnectorNative(String name) throws IOException;
     private static native long requestNative(long handle);
     private static native void waitNative(long handle, long id);
@@ -21,43 +27,44 @@ public final class IpcConnectorImpl implements Connector {
     private static native void closeConnectorNative(long handle);
 
     static {
-	System.loadLibrary("wire");
+        System.loadLibrary("wire");
     }
 
-    String name;
+    private final String name;
     long handle;
     long id;
-    
-    public IpcConnectorImpl(String name) {
-	this.name = name;
-    }
-    
-    public Future<SessionWire> connect() throws IOException {
-        LoggerFactory.getLogger(IpcConnectorImpl.class).trace("will connect to " + name);
 
-	handle = getConnectorNative(name);
-	id = requestNative(handle);
-	return new FutureSessionWireImpl(this);
+    public IpcConnectorImpl(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Future<SessionWire> connect(Credential credential) throws IOException {
+        LOG.trace("will connect to {}", name); //$NON-NLS-1$
+
+        handle = getConnectorNative(name);
+        id = requestNative(handle);
+        return new FutureSessionWireImpl(this);
     }
 
     public SessionWire getSessionWire() throws IOException {
-	waitNative(handle, id);
-	close();
-	return new SessionWireImpl(name, id);
+        waitNative(handle, id);
+        close();
+        return new SessionWireImpl(name, id);
     }
 
     public SessionWire getSessionWire(long timeout, TimeUnit unit) throws TimeoutException, IOException {
-	var timeoutNano = unit.toNanos(timeout);
-	if (timeoutNano == Long.MIN_VALUE) {
-	    throw new IOException("timeout duration overflow");
-	}
-	waitNative(handle, id, timeoutNano);
-	close();
-	return new SessionWireImpl(name, id);
+        var timeoutNano = unit.toNanos(timeout);
+        if (timeoutNano == Long.MIN_VALUE) {
+            throw new IOException("timeout duration overflow");
+        }
+        waitNative(handle, id, timeoutNano);
+        close();
+        return new SessionWireImpl(name, id);
     }
 
     public boolean checkConnection() {
-	return checkNative(handle, id);
+        return checkNative(handle, id);
     }
 
     /**
@@ -65,9 +72,9 @@ public final class IpcConnectorImpl implements Connector {
      * @throws IOException close error
      */
     public void close() throws IOException {
-	if (handle != 0) {
-	    closeConnectorNative(handle);
-	}
-	handle = 0;
+        if (handle != 0) {
+            closeConnectorNative(handle);
+        }
+        handle = 0;
     }
 }

--- a/modules/ipc/src/main/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
+++ b/modules/ipc/src/main/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
@@ -1,0 +1,1 @@
+com.nautilus_technologies.tsubakuro.channel.ipc.connection.IpcConnectorFactory

--- a/modules/ipc/src/test/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorFactoryTest.java
+++ b/modules/ipc/src/test/java/com/nautilus_technologies/tsubakuro/channel/ipc/connection/IpcConnectorFactoryTest.java
@@ -1,0 +1,33 @@
+package com.nautilus_technologies.tsubakuro.channel.ipc.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.Test;
+
+import com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory;
+
+class IpcConnectorFactoryTest {
+
+    @Test
+    void spi() {
+        assertTrue(ServiceLoader.load(ConnectorFactory.class)
+                .stream()
+                .anyMatch(it -> it.type() == IpcConnectorFactory.class));
+    }
+
+    @Test
+    void tryCreate() {
+        var factory = new IpcConnectorFactory();
+
+        assertTrue(factory.tryCreate(URI.create("ipc:example")).isPresent());
+        assertTrue(factory.tryCreate(URI.create("ipc:example?query")).isPresent());
+
+        assertFalse(factory.tryCreate(URI.create("example:ipc")).isPresent());
+        assertFalse(factory.tryCreate(URI.create("tcp://localhost:8081/")).isPresent());
+        assertFalse(factory.tryCreate(URI.create("http://www.example.com/")).isPresent());
+    }
+}

--- a/modules/stream/build.gradle
+++ b/modules/stream/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+
     api 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.msgpack:msgpack-core:0.8.24'
     testImplementation 'org.slf4j:slf4j-nop:1.7.32'

--- a/modules/stream/src/main/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorFactory.java
+++ b/modules/stream/src/main/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorFactory.java
@@ -1,0 +1,57 @@
+package com.nautilus_technologies.tsubakuro.channel.stream.connection;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory;
+
+/**
+ * An implementation of {@link ConnectorFactory} which provides instances of {@link StreamConnectorImpl}.
+ *
+ * This factory can handle {@code tcp://<host>:<port>} style end-point URI, and will ignore other parts of it.
+ */
+public class StreamConnectorFactory implements ConnectorFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamConnectorFactory.class);
+
+    private static final String SCHEME = "tcp"; //$NON-NLS-1$
+
+    @Override
+    public Optional<StreamConnectorImpl> tryCreate(@Nonnull URI endpoint) {
+        Objects.requireNonNull(endpoint);
+
+        LOG.trace("testing whether or not URI is suitable for {} connector: '{}'", SCHEME, endpoint); //$NON-NLS-1$
+
+        if (!Objects.equals(endpoint.getScheme(), SCHEME)) {
+            LOG.trace("URI is not suitable for {} connector: '{}' (invalid scheme)", SCHEME, endpoint); //$NON-NLS-1$
+            return Optional.empty();
+        }
+
+        var host = endpoint.getHost();
+        if (Objects.isNull(host)) {
+            LOG.trace("URI is not suitable for {} connector: '{}' (invalid host)", SCHEME, endpoint); //$NON-NLS-1$
+            return Optional.empty();
+        }
+
+        var port = endpoint.getPort();
+        if (port < 0) {
+            LOG.trace("URI is not suitable for {} connector: '{}' (invalid port)", SCHEME, endpoint); //$NON-NLS-1$
+            return Optional.empty();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("recognized endpoit URI scheme='{}', host='{}', port={}", new Object[] { //$NON-NLS-1$
+                    SCHEME,
+                    host,
+                    port,
+            });
+        }
+        return Optional.of(new StreamConnectorImpl(host, port));
+    }
+}

--- a/modules/stream/src/main/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorImpl.java
+++ b/modules/stream/src/main/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorImpl.java
@@ -2,8 +2,11 @@ package com.nautilus_technologies.tsubakuro.channel.stream.connection;
 
 import java.util.concurrent.Future;
 import java.io.IOException;
+
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.nautilus_technologies.tsubakuro.channel.common.connection.Connector;
+import com.nautilus_technologies.tsubakuro.channel.common.connection.Credential;
 import com.nautilus_technologies.tsubakuro.channel.common.sql.SessionWire;
 import com.nautilus_technologies.tsubakuro.channel.stream.StreamWire;
 
@@ -11,20 +14,24 @@ import com.nautilus_technologies.tsubakuro.channel.stream.StreamWire;
  * StreamConnectorImpl type.
  */
 public final class StreamConnectorImpl implements Connector {
-    public static final int DEFAULT_PORT = 12345; 
-    private String hostname;
-    private int port;
-    
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamConnectorImpl.class);
+
+    public static final int DEFAULT_PORT = 12345;
+    private final String hostname;
+    private final int port;
+
     public StreamConnectorImpl(String hostname, int port) {
-	this.hostname = hostname;
-	this.port = port;
+        this.hostname = hostname;
+        this.port = port;
     }
 
-    public Future<SessionWire> connect() throws IOException {
-	LoggerFactory.getLogger(StreamConnectorImpl.class).trace("will connect to " + hostname + ":" + port);
+    @Override
+    public Future<SessionWire> connect(Credential credential) throws IOException {
+        LOG.trace("will connect to {}:{}", hostname, port); //$NON-NLS-1$
 
-	var streamWire = new StreamWire(hostname, port);
-	streamWire.hello();
-	return new FutureSessionWireImpl(streamWire);
+        var streamWire = new StreamWire(hostname, port);
+        streamWire.hello();
+        return new FutureSessionWireImpl(streamWire);
     }
 }

--- a/modules/stream/src/main/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
+++ b/modules/stream/src/main/resources/META-INF/services/com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory
@@ -1,0 +1,1 @@
+com.nautilus_technologies.tsubakuro.channel.stream.connection.StreamConnectorFactory

--- a/modules/stream/src/test/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorFactoryTest.java
+++ b/modules/stream/src/test/java/com/nautilus_technologies/tsubakuro/channel/stream/connection/StreamConnectorFactoryTest.java
@@ -1,0 +1,38 @@
+package com.nautilus_technologies.tsubakuro.channel.stream.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.Test;
+
+import com.nautilus_technologies.tsubakuro.channel.common.connection.ConnectorFactory;
+
+class StreamConnectorFactoryTest {
+
+    @Test
+    void spi() {
+        assertTrue(ServiceLoader.load(ConnectorFactory.class)
+                .stream()
+                .anyMatch(it -> it.type() == StreamConnectorFactory.class));
+    }
+
+    @Test
+    void testTryCreate() {
+        var factory = new StreamConnectorFactory();
+
+        assertTrue(factory.tryCreate(URI.create("tcp://localhost:8081")).isPresent());
+        assertFalse(factory.tryCreate(URI.create("tcp://localhost")).isPresent());
+
+        // other than host:port parts will be ignored
+        assertTrue(factory.tryCreate(URI.create("tcp://localhost:8081/")).isPresent());
+        assertTrue(factory.tryCreate(URI.create("tcp://localhost:8081/path/to/something?query")).isPresent());
+        assertTrue(factory.tryCreate(URI.create("tcp://user:pass@localhost:8081")).isPresent());
+
+        assertFalse(factory.tryCreate(URI.create("udp://localhost:8081")).isPresent());
+        assertFalse(factory.tryCreate(URI.create("http://www.example.com/")).isPresent());
+        assertFalse(factory.tryCreate(URI.create("ipc:tsurugi")).isPresent());
+    }
+}


### PR DESCRIPTION
This PR introduces `Connector.create(URI)` method, that enables find suitable `Connector` implementation from the specified URI.

This also `Connector.connect(Credential)`, but each implementation will omit the passed credential information.

Note that, `ConnectorImpl` in `connector` submodule will become superseded by this PR.
Please consider whether to remove it.
