### PR TITLE
Integration-Test only runs on master or PR(non-draft)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,6 +74,7 @@ jobs:
 
   Integration_Test:
     uses: ./.github/workflows/integration-test.yml
+    if: always() && (github.event.pull_request.draft == false) && (contains(github.ref, '/tags/') || contains(github.ref, '/pull/') || contains(github.ref, '/heads/master'))
     needs: Build
     secrets:
       GHA_PAT: ${{ secrets.GHA_PAT }}


### PR DESCRIPTION
結合テストのCI Wokflowの実行を、masterブランチ または Pull Request (Draft指定がないもの) のみに限定するよう変更します。

