### PR TITLE
add DescribeTable proto msg

### DIFF
--- a/modules/proto/src/main/protos/request.proto
+++ b/modules/proto/src/main/protos/request.proto
@@ -221,6 +221,14 @@ message Explain {
   repeated Parameter parameters = 2;
 }
 
+// describe about the table.
+message DescribeTable {
+    reserved 1 to 10;
+
+    // the table name to describe.
+    string name = 11;
+}
+
 /* For request message to the SQL service. */
 message Request {
   common.Session session_handle = 1;
@@ -238,5 +246,6 @@ message Request {
     Explain explain = 12;
     ExecuteDump execute_dump = 13;
     ExecuteLoad execute_load = 14;
+    DescribeTable describe_table = 15;
   }
 }

--- a/modules/proto/src/main/protos/response.proto
+++ b/modules/proto/src/main/protos/response.proto
@@ -67,6 +67,36 @@ message Explain {
   }
 }
 
+// describe about a table.
+message DescribeTable {
+  reserved 1 to 10;
+
+  // request is successfully completed.
+  message Success {
+
+    // the database name.
+    string database_name = 1;
+
+    // the schema name.
+    string schema_name = 2;
+
+    // the table name.
+    string table_name = 3;
+
+    // the table column information.
+    repeated common.Column columns = 4;
+  }
+
+  // the response body.
+  oneof result {
+    // request is successfully completed.
+    Success success = 11;
+
+    // engine error was occurred.
+    Error error = 12;
+  }
+}
+
 /* For response message from the SQL service. */
 message Response {
   oneof response {
@@ -75,5 +105,6 @@ message Response {
     Prepare prepare = 3;
     ExecuteQuery execute_query = 4;
     Explain explain = 5;
+    DescribeTable describe_table = 6;
   }
 }


### PR DESCRIPTION
DescribeTable用のrequest/responseメッセージを追加する変更です。
@t-horikawa 確認の上、問題なければマージお願いします。

[sandbox-tsubakuro](https://github.com/project-tsurugi/sandbox-tsubakuro/tree/master/modules/sql/src/main/proto/jogasaki/proto/sql)とほぼ同じですが、エラー時に戻る結果のEngineErrorはまだ導入していないのでErrorにしてあります。