### PR TITLE
Remove unnecessary spotbugs filter

### DIFF
--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -13,9 +13,3 @@ dependencies {
 
     api project(':proto')
 }
-
-spotbugsMain {
-    onlyAnalyze = [
-        'com.nautilus_technologies.tsubakuro.impl.low.sql.*'
-    ]
-}


### PR DESCRIPTION
commonモジュールに不要なSpotBugsのクラスフィルタが存在していたので削除します。
おそらくproto系がcommonに含まれていた時には必要だったと思うのですが、今は分離しているのでこのフィルタは不要です。

このフィルタ削除により、SpotBugsのチェックに3件ひっかかるようになります。
いずれも不適切なコードである可能性があるので、マージ後に確認おねがいします。