### PR TITLE
Improve CheckStyle rules

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -31,17 +31,13 @@
     <module name="PackageName"/>
     <module name="PackageDeclaration"/>
     <module name="ParameterName"/>
-    <module name="StaticVariableName">
-      <property name="severity" value="error"/>
-    </module>
+    <module name="StaticVariableName"/>
     <module name="TypeName"/>
     <!-- <module name="AvoidStarImport"> <property name="allowStaticMemberImports" value="true"/> </module> -->
     <module name="IllegalImport"/>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="MethodLength">
-      <property name="severity" value="error"/>
-    </module>
+    <module name="MethodLength"/>
     <module name="ParameterNumber">
       <property name="max" value="10"/>
     </module>


### PR DESCRIPTION
CheckStyleのルールを以下のように改善
* パッケージ名とディレクトリ構成が異なる場合にワーニングとするルールを追加
* いくつかのコード表記に関するルールのseverityをerrorからwarningに修正(他のルールとの整合性を合わせる)

これによりワーニングが1つ検知されるので、マージ後に対応おねがいします。
なおexamplesは別の要因により検知できていないので、別Pull Requestにて対応します。
