### PR TITLE
Change artifact name of native library

### DIFF
--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 publishing {
     publications {
         mavenNative(MavenPublication) {
-            artifactId = "libwire"
+            artifactId = "${rootProject.name}-libwire"
             artifact "${buildDir}/native/libwire.so"
         }
     }


### PR DESCRIPTION
#81 の対応が不完全で、Native Libraryのartifact nameのプレフィックスに `tsubakuro-` が追加されていない問題を修正しました
