### PR TITLE
dump/loadのexampleの更新

### DIFF
--- a/modules/examples/src/main/java/com/nautilus_technologies/tsubakuro/examples/dumpload/Select.java
+++ b/modules/examples/src/main/java/com/nautilus_technologies/tsubakuro/examples/dumpload/Select.java
@@ -1,8 +1,6 @@
 package com.nautilus_technologies.tsubakuro.examples.dumpload;
 
 import com.nautilus_technologies.tsubakuro.exception.ServerException;
-import com.nautilus_technologies.tsubakuro.low.sql.Parameters;
-import com.nautilus_technologies.tsubakuro.low.sql.Placeholders;
 import com.nautilus_technologies.tsubakuro.low.sql.ResultSet;
 import com.nautilus_technologies.tsubakuro.low.sql.SqlClient;
 import com.tsurugidb.jogasaki.proto.SqlResponse;
@@ -51,7 +49,7 @@ public class Select {
         }
     }
 
-    static public void prepareAndSelect(SqlClient sqlClient, String sql) throws IOException, ServerException, InterruptedException {
+    static void prepareAndSelect(SqlClient sqlClient, String sql) throws IOException, ServerException, InterruptedException {
         try (var preparedStatement = sqlClient.prepare(sql).await();
              var transaction = sqlClient.createTransaction().await()) {
             var resultSet = transaction.executeQuery(preparedStatement).get();


### PR DESCRIPTION
dump/loadはこれまで手元でjavaコードを書いて動作確認していましたが、オプション等の追加もあるのでtsubakuroの動作確認用exampleを更新させてもらえればと思います。

**使用方法**
必要なテーブルを作成(初回実行に必要)してdump/loadを実行し、loadされたテーブルの内容を表示
$ gradlew runDump --args="-t"

上と同じだがテーブルの作成は行わない(2回目以降の実行用)
$ gradlew runDump 

dumpは上と同様、load時にステートメント生成ユーティリティを使って生成されたものを使ってloadを行う
$ gradlew runDump --args="-s"