### PR TITLE
Fix integration test when pull request build

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,9 +4,12 @@ name: Tsubakuro-Integration-Test
 # * Use docker service container
 #   * Not install server modules locally
 #   * Connect to the server process using TCP connection
-# * Get client libraries via remote Maven repository
+# * (When build to master) Get client libraries via remote Maven repository
 #   * run gradlew with --refresh-dependencies to download latest artifacts
 #   * Not install client libraries locally
+# * (When build to pull request) Use locally installed client libraries
+#   * Install client libraries locally within the workflow
+#   * Enable mavenLocal (and disable remote Maven repository)
 # * Trigger after ci-build.yml(workflow_call), manually(workflow_dispatch)
 
 on:
@@ -36,6 +39,7 @@ jobs:
         shell: bash
     env:
       TG_IT_RESULT_PATH: itest/result
+      TG_IT_TSUBAKURO_PATH: .
       TG_IT_EISEN_PATH: itest/eisen
 
       GPR_USER: ${{ github.repository_owner }}
@@ -90,6 +94,14 @@ jobs:
         env:
           TG_IT_RESULT_DIR: ${{ github.workspace }}/${{ env.TG_IT_RESULT_PATH }}
 
+      - id: Install_Tsubakuro
+        name: Install_Tsubakuro
+        run: ${{ env.TG_IT_EISEN_PATH }}/scripts/install-tsubakuro.sh 2>&1 | tee ${TG_IT_RESULT_DIR}/install-tsubakuro.log
+        env:
+          TG_IT_TSUBAKURO_DIR: ${{ github.workspace }}/${{ env.TG_IT_TSUBAKURO_PATH }}
+          TG_IT_RESULT_DIR: ${{ github.workspace }}/${{ env.TG_IT_RESULT_PATH }}
+        if: contains(github.ref, '/pull/')
+
       - id: Integration_Test
         name: Integration_Test
         shell: bash --noprofile --norc -x {0}
@@ -97,7 +109,7 @@ jobs:
         env:
           TG_IT_EISEN_DIR: ${{ github.workspace }}/${{ env.TG_IT_EISEN_PATH }}
           TG_IT_RESULT_DIR: ${{ github.workspace }}/${{ env.TG_IT_RESULT_PATH }}
-          GRADLE_CLI_OPTS: --refresh-dependencies
+          GRADLE_CLI_OPTS: ${{ (contains(github.ref, '/pull/')) && '-PmavenLocal' || '--refresh-dependencies' }}
 
       - id: Prepare_Upload
         name: Prepare_Upload


### PR DESCRIPTION
Pull Request時のIntegration Testで使うTsubakuroは、対象コミットに対してローカルインストールしたものを使うよう修正。