### PR TITLE
Improve project artifacts

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -65,7 +65,7 @@ jar {
 
 artifacts {
     archives tasks.sourcesJar
-    archives tasks.testsJar
+    //archives tasks.testsJar
 }
 
 tasks.named('test') {


### PR DESCRIPTION
* jar manifestにビルドタイムスタンプやコミットIDなどを追加
* testsJarは当面リモートリポジトリから使用しないため削除