### PR TITLE
add trace log in result set input.

### DIFF
--- a/modules/session/src/main/java/com/nautilus_technologies/tsubakuro/low/sql/io/StreamBackedValueInput.java
+++ b/modules/session/src/main/java/com/nautilus_technologies/tsubakuro/low/sql/io/StreamBackedValueInput.java
@@ -144,7 +144,7 @@ public class StreamBackedValueInput implements ValueInput {
         if (currentEntryType == null) {
             fetchHeader();
             if (LOG.isTraceEnabled()) {
-                LOG.trace("read entry: {} ()", currentEntryType, currentHeaderCategory); //$NON-NLS-1$
+                LOG.trace("read entry: {} ({})", currentEntryType, currentHeaderCategory); //$NON-NLS-1$
             }
         }
         assert currentEntryType != null;


### PR DESCRIPTION
The logger name is `com.nautilus_technologies.tsubakuro.low.sql.io.StreamBackedValueInput`; this may be changed.