### PR TITLE
add TimeUnit to select dumped timestamp resolution

### DIFF
--- a/modules/proto/src/main/protos/tateyama/proto/sql/common.proto
+++ b/modules/proto/src/main/protos/tateyama/proto/sql/common.proto
@@ -190,3 +190,15 @@ message Clob {
 message Blob {
     // FIXME impl
 }
+
+// unit for time and timestamp value
+enum TimeUnit {
+    // unit unspecified.
+    TIME_UNIT_UNSPECIFIED = 0;
+    // unit nano-second.
+    NANOSECOND = 1;
+    // unit micro-second.
+    MICROSECOND = 2;
+    // unit milli-second.
+    MILLISECOND = 3;
+}

--- a/modules/proto/src/main/protos/tateyama/proto/sql/request.proto
+++ b/modules/proto/src/main/protos/tateyama/proto/sql/request.proto
@@ -243,6 +243,9 @@ message DumpOption {
 
     // record count limit for dump output file
     uint64 max_record_count_per_file = 12;
+
+    // time unit used for timestamp columns
+    common.TimeUnit timestamp_unit = 13;
 }
 
 /* For execute dump request. */


### PR DESCRIPTION
オプションでDump実行時のTimestamp列の値の単位(ナノ秒・マイクロ秒・ミリ秒)を指定できるようにするためのメッセージ変更です。