### PR TITLE
revise Gradle `writeVersion` task.

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.tsurugidb.tsubakuro'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+ext {
+    tsubakuroVersion = '0.0.1-SNAPSHOT'
+    buildTimestamp = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    buildRevision = System.getenv("GITHUB_SHA") ?: ""
+    createdBy = "Gradle ${gradle.gradleVersion}"
+    buildJdk = "${javaToolchains.launcherFor(java.toolchain).get().getMetadata().javaRuntimeVersion} ${javaToolchains.launcherFor(java.toolchain).get().getMetadata().vendor} ${javaToolchains.launcherFor(java.toolchain).get().getMetadata().jvmVersion}"
+    buildOs = "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+}
+
+tasks.withType(JavaCompile) { task ->
+    task.options.encoding 'UTF-8'
+}
+
+tasks.withType(Javadoc) { task ->
+    task.options.encoding 'UTF-8'
+}

--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -1,21 +1,16 @@
 plugins {
-    id 'java'
+    id 'tsubakuro.java-base'
     id 'checkstyle'
 
     id 'com.github.spotbugs'
 }
 
-group = 'com.tsurugidb.tsubakuro'
-version = '0.0.1-SNAPSHOT'
 
 repositories {
     mavenCentral()
 }
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
     withSourcesJar()
 }
 
@@ -43,10 +38,6 @@ spotbugsMain {
 spotbugsTest.enabled = false
 checkstyleTest.enabled = false
 
-tasks.withType(JavaCompile) { task ->
-    task.options.encoding = 'UTF-8'
-}
-
 task testsJar(type: Jar) {
     classifier 'tests'
     from sourceSets.test.output
@@ -54,28 +45,28 @@ task testsJar(type: Jar) {
 
 jar {
     manifest.attributes (
-        'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
-        'Build-Revision' : System.getenv("GITHUB_SHA") ?: "",
-        'Created-By'     : "Gradle ${gradle.gradleVersion}",
-        'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+        'Build-Timestamp': buildTimestamp,
+        'Build-Revision' : buildRevision,
+        'Created-By'     : createdBy,
+        'Build-Jdk'      : buildJdk,
+        'Build-OS'       : buildOs,
     )
 }
 
 task writeVersion(type: WriteProperties) {
     description 'generate version file to META-INF/tsurugidb/{project.name}.properties'
-    inputs.property('Build-Revision', System.getenv("GITHUB_SHA") ?: "")
-    outputs.dir("${project.buildDir}/generated/version")
+    inputs.property('Build-Revision', buildRevision)
     outputFile "${project.buildDir}/generated/version/META-INF/tsurugidb/${project.name}.properties"
     properties (
-        'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
-        'Build-Revision' : System.getenv("GITHUB_SHA") ?: "",
-        'Created-By'     : "Gradle ${gradle.gradleVersion}",
-        'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+        'Build-Timestamp': buildTimestamp,
+        'Build-Revision' : buildRevision,
+        'Created-By'     : createdBy,
+        'Build-Jdk'      : buildJdk,
+        'Build-OS'       : buildOs,
     )
 }
-sourceSets.main.output.dir(writeVersion)
+sourceSets.main.output.dir("${project.buildDir}/generated/version")
+processResources.dependsOn writeVersion
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/buildSrc/src/main/groovy/tsubakuro.javadocs.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.javadocs.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'tsubakuro.java-base'
 }
 
 def clientApiProjects = [


### PR DESCRIPTION
This PR revise local gradle plugins to avoid problematic behavior of Eclipse buildship (sometimes `.classpath` will be broken).