### PR TITLE
update ERR_ABORTED_RETRYABLE to ERR_SERIALIZATION_FAILURE

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
@@ -84,9 +84,9 @@ public enum SqlServiceCode implements DiagnosticCode {
     ERR_ABORTED(-10, SqlStatus.Status.ERR_ABORTED),
 
     /**
-     * ERR_ABORTED_RETRYABLE
+     * ERR_SERIALIZATION_FAILURE
      */
-    ERR_ABORTED_RETRYABLE(-11, SqlStatus.Status.ERR_ABORTED_RETRYABLE),
+    ERR_SERIALIZATION_FAILURE(-11, SqlStatus.Status.ERR_ABORTED_RETRYABLE),
 
     /**
      * ERR_NOT_FOUND
@@ -164,6 +164,13 @@ public enum SqlServiceCode implements DiagnosticCode {
     ERR_DATA_CORRUPTION(-26, SqlStatus.Status.ERR_DATA_CORRUPTION),
 
     ;
+
+    /**
+     * ERR_ABORTED_RETRYABLE for backward compatibility
+     */
+    @Deprecated
+    public static final SqlServiceCode ERR_ABORTED_RETRYABLE = ERR_SERIALIZATION_FAILURE;
+
     private final int codeNumber;
 
     private final SqlStatus.Status mapping;


### PR DESCRIPTION
ERR_ABORTED_RETRYABLEはgenericなシリアライゼーション違反のステータス通知で使用されていますが、リトライ可能であることを前面に出しすぎて名前が本質とずれているのでラベルをERR_SERIALIZATION_FAILUREと変更します。

この変更によって、コード番号(-11)はERR_ABORTED_RETRYABLEラベル からERR_SERIALIZATION_FAILURE ラベルに変更になります。ERR_ABORTED_RETRYABLEはSqlServiceCode内にエイリアスとして残しますのでリフレクションや文字列表現そのものを使用していない限りは既存のコードのERR_ABORTED_RETRYABLEを使うことが可能です。(ただし可能な限り早くERR_SERIALIZATION_FAILURE に変更するのが推奨されます)