### PR TITLE
Remove tsubakuro-jni publication

### DIFF
--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -11,19 +11,3 @@ dependencies {
 
     implementation project(':tsubakuro-common')
 }
-
-publishing {
-    publications {
-        mavenNative(MavenPublication) {
-            artifactId = "${rootProject.name}-jni"
-            artifact "${buildDir}/native/lib/libtsubakuro.so"
-        }
-    }
-}
-
-tasks.withType(AbstractPublishToMaven) { task ->
-    if (task.name == 'publishMavenNativePublicationToMavenLocal' ||
-        task.name == 'publishMavenNativePublicationToGitHubPackagesRepository') {
-        task.dependsOn nativeLib
-    }
-}


### PR DESCRIPTION
アプリケーションはサーバ側のインストーラーで配置される libtsubakuro.so を利用する方針としたため、 libtsubakuro.soをMavenリモートリポジトリで管理する機能を廃止します。
関連: #305 