### PR TITLE
Change default of `com.tsurugidb.tsubakuro.jniverify` to false

### DIFF
--- a/docs/native-library-ja.md
+++ b/docs/native-library-ja.md
@@ -17,4 +17,4 @@
 
 * JNI ライブラリのロードに、Java ライブラリと JNI ライブラリのビルドの一貫性を検証し、不整合があればエラー終了する
   * ビルド時の環境変数 `GITHUB_SHA` を一貫性の識別子として利用する
-* 上記のエラーを抑制するには、システムプロパティ `com.tsurugidb.tsubakuro.jniverify=false` を指定する
+* デフォルトではこの検証は無効になっている。有効にするには、システムプロパティ `com.tsurugidb.tsubakuro.jniverify=true` を指定する

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/NativeLibrary.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/NativeLibrary.java
@@ -55,7 +55,7 @@ public final class NativeLibrary {
     /**
      * The default value of {@link #KEY_PROPERTY_VERIFY_VERSION}.
      */
-    public static final boolean DEFAULT_VERIFY_VERSION = true;
+    public static final boolean DEFAULT_VERIFY_VERSION = false;
 
     private static final boolean REQUIRE_VERIFY_VERSION =
             Optional.ofNullable(System.getProperty(KEY_PROPERTY_VERIFY_VERSION))


### PR DESCRIPTION
以前議論した通り、 Java ライブラリと JNI ライブラリのビルドの一貫性検証にコミットハッシュ値を使うことは、ユーザ側でJavaライブラリのみをアップデートする運用が行えないなどの問題があるため、デフォルトでこの一貫性検証を無効にします。

一貫性検証を適切に行うために、コミットハッシュ値に変わる検証方法を考案する必要がありますが、こちらについては別途管理します。