### PR TITLE
Add `-PskipBuildNative` for skipping build native library

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ where ${ProjectTopDirectory} is a directory created by clone of the tsubakuro re
 Build only java libraries and skip testing and building native libraries.
 
 ```
-./gradlew assemble -x tsubakuro-ipc:nativeLib
+./gradlew assemble -PskipBuildNative
 ```
 
 ### install
@@ -50,7 +50,7 @@ Build and deploy the java and native libraries into Maven Local Repository.
 ### install only java libraries
 Build and deploy only the java libraries into Maven Local Repository.
 ```
-./gradlew PublishMavenJavaPublicationToMavenLocal
+./gradlew PublishMavenJavaPublicationToMavenLocal -PskipBuildNative
 ```
 
 ### generate all(aggregated) Javadoc

--- a/buildSrc/src/main/groovy/tsubakuro.jni-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.jni-library-conventions.gradle
@@ -118,32 +118,34 @@ task cmakeTestBuild {
     }
 }
 
-assemble.dependsOn nativeLib
-test.dependsOn cmakeBuild
-test.dependsOn cmakeTestBuild
+if (!hasProperty('skipBuildNative')) {
+    assemble.dependsOn nativeLib
+    test.dependsOn cmakeBuild
+    test.dependsOn cmakeTestBuild
 
-cmakeConfigure.dependsOn compileJava
-cmakeTestConfigure.dependsOn compileTestJava
+    cmakeConfigure.dependsOn compileJava
+    cmakeTestConfigure.dependsOn compileTestJava
 
-cmakeBuild.dependsOn cmakeConfigure
-cmakeTestBuild.dependsOn cmakeTestConfigure
+    cmakeBuild.dependsOn cmakeConfigure
+    cmakeTestBuild.dependsOn cmakeTestConfigure
 
-nativeLib.dependsOn cmakeBuild
+    nativeLib.dependsOn cmakeBuild
 
-clean {
-    delete += "$nativeBuildDir"
-}
-cleanTest {
-    delete += "$nativeTestBuildDir"
-}
+    clean {
+        delete += "$nativeBuildDir"
+    }
+    cleanTest {
+        delete += "$nativeTestBuildDir"
+    }
 
-compileJava {
-    options.headerOutputDirectory = file("${nativeIncludeDir}")
-}
-compileTestJava {
-    options.headerOutputDirectory = file("${nativeTestIncludeDir}")
-}
+    compileJava {
+        options.headerOutputDirectory = file("${nativeIncludeDir}")
+    }
+    compileTestJava {
+        options.headerOutputDirectory = file("${nativeTestIncludeDir}")
+    }
 
-tasks.named('test') {
-    systemProperty 'java.library.path', "${nativeBuildDir}/src:${nativeTestBuildDir}/src"
+    tasks.named('test') {
+        systemProperty 'java.library.path', "${nativeBuildDir}/src:${nativeTestBuildDir}/src"
+    }
 }


### PR DESCRIPTION
ビルドオプション `-PskipBuildNative` を指定することにより modules/ipc 配下のネイティブライブラリ用のGradleタスクやビルド設定を無効化することを可能にします。
