### PR TITLE
breaking change in API of Transaction.executeStatement(), Transaction.executeLoad(), and SqlClient.executeLoad()

### DIFF
--- a/modules/proto/src/main/protos/jogasaki/proto/sql/response.proto
+++ b/modules/proto/src/main/protos/jogasaki/proto/sql/response.proto
@@ -40,7 +40,7 @@ message Error {
  */
 
 /* For response to ExecuteQuery, ExecutePreparedQuery, Commit, Rollback, 
-DisposePreparedStatement, DisposeTransaction, ExecuteDump and ExecuteLoad. */
+DisposePreparedStatement, DisposeTransaction, and ExecuteDump. */
 message ResultOnly {
   oneof result {
     Success success = 1;
@@ -240,7 +240,7 @@ message DisposeTransaction {
   }
 }
 
-/* For response to ExecuteStatement and ExecutePreparedStatement. */
+/* For response to ExecuteStatement, ExecutePreparedStatement, and ExecuteLoad. */
 message ExecuteResult {
   reserved 1 to 10;
 

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
@@ -164,7 +164,7 @@ public interface SqlClient extends ServerResource {
      * @throws IOException if I/O error was occurred while sending request
      * @see Parameters
      */
-    default FutureResponse<Void> executeLoad(
+    default FutureResponse<ExecuteResult> executeLoad(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters,
             @Nonnull Collection<? extends Path> files) throws IOException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
@@ -103,10 +103,10 @@ public interface SqlService extends ServerResource {
      *      which may raise error if the request was failed.
      * @throws IOException if I/O error was occurred while sending the request
      */
-    default FutureResponse<Void> send(@Nonnull SqlRequest.ExecuteStatement request) throws IOException {
+    default FutureResponse<ExecuteResult> send(@Nonnull SqlRequest.ExecuteStatement request) throws IOException {
         throw new UnsupportedOperationException();
     }
-    default FutureResponse<Void> send(@Nonnull SqlRequest.ExecutePreparedStatement request) throws IOException {
+    default FutureResponse<ExecuteResult> send(@Nonnull SqlRequest.ExecutePreparedStatement request) throws IOException {
         throw new UnsupportedOperationException();
     }
 

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
@@ -155,7 +155,7 @@ public interface SqlService extends ServerResource {
      *      which may raise error if the request was failed.
      * @throws IOException if I/O error was occurred while sending the request
      */
-    default FutureResponse<Void> send(@Nonnull SqlRequest.ExecuteLoad request) throws IOException {
+    default FutureResponse<ExecuteResult> send(@Nonnull SqlRequest.ExecuteLoad request) throws IOException {
         throw new UnsupportedOperationException();
     }
 

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -205,7 +205,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * @return a future response of the result set
      * @throws IOException if I/O error was occurred while sending request
      */
-    default FutureResponse<Void> executeLoad(
+    default FutureResponse<ExecuteResult> executeLoad(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters,
             @Nonnull Path... files) throws IOException {
@@ -234,7 +234,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * @throws IOException if I/O error was occurred while sending request
      * @see Parameters
      */
-    default FutureResponse<Void> executeLoad(
+    default FutureResponse<ExecuteResult> executeLoad(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters,
             @Nonnull Collection<? extends Path> files) throws IOException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -26,7 +26,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * @return a future response of the action
      * @throws IOException if I/O error was occurred while sending request
      */
-    default FutureResponse<Void> executeStatement(@Nonnull String source) throws IOException {
+    default FutureResponse<ExecuteResult> executeStatement(@Nonnull String source) throws IOException {
         throw new UnsupportedOperationException();
     }
 
@@ -39,7 +39,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * @return a future response of the action
      * @throws IOException if I/O error was occurred while sending request
      */
-    default FutureResponse<Void> executeStatement(
+    default FutureResponse<ExecuteResult> executeStatement(
             @Nonnull PreparedStatement statement,
             @Nonnull SqlRequest.Parameter... parameters) throws IOException {
         Objects.requireNonNull(statement);
@@ -56,7 +56,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * @return a future response of the action
      * @throws IOException if I/O error was occurred while sending request
      */
-    default FutureResponse<Void> executeStatement(
+    default FutureResponse<ExecuteResult> executeStatement(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters) throws IOException {
         throw new UnsupportedOperationException();

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ExecuteResultAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ExecuteResultAdapter.java
@@ -17,6 +17,9 @@ public class ExecuteResultAdapter implements ExecuteResult {
     private final HashSet<CounterType> counterTypes = new HashSet<>();
     private final HashMap<CounterType, Long> counters = new HashMap<>();
 
+    ExecuteResultAdapter() {
+    }
+
     ExecuteResultAdapter(SqlResponse.ExecuteResult.Success executeResult) throws IOException {
         var result = executeResult.getCountersList();
         for (var e : result) {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlClientImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlClientImpl.java
@@ -19,6 +19,7 @@ import com.tsurugidb.tsubakuro.sql.StatementMetadata;
 import com.tsurugidb.tsubakuro.sql.TableList;
 import com.tsurugidb.tsubakuro.sql.TableMetadata;
 import com.tsurugidb.tsubakuro.sql.Transaction;
+import com.tsurugidb.tsubakuro.sql.ExecuteResult;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
 
 /**
@@ -93,7 +94,7 @@ public class SqlClientImpl implements SqlClient {
     }
 
     @Override
-    public FutureResponse<Void> executeLoad(
+    public FutureResponse<ExecuteResult> executeLoad(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters,
             @Nonnull Collection<? extends Path> files) throws IOException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
@@ -449,7 +449,7 @@ public class SqlServiceStub implements SqlService {
                         var errorResponse = resultOnlyResponse.getError();
                         throw SqlServiceException.of(SqlServiceCode.valueOf(errorResponse.getCode()), errorResponse.getDetail());
                     }
-                    return null;
+                    return new ExecuteResultAdapter();
             }
             throw new IOException("response type is inconsistent with the request type");
         }
@@ -654,31 +654,39 @@ public class SqlServiceStub implements SqlService {
                     new QueryProcessor(request));
     }
 
-    static class LoadProcessor implements MainResponseProcessor<Void> {
-        private final AtomicReference<SqlResponse.ResultOnly> detailResponseCache = new AtomicReference<>();
+    static class LoadProcessor implements MainResponseProcessor<ExecuteResult> {
+        private final AtomicReference<SqlResponse.Response> responseCache = new AtomicReference<>();
 
         @Override
-        public Void process(ByteBuffer payload) throws IOException, ServerException, InterruptedException {
-            if (detailResponseCache.get() == null) {
-                var response = SqlResponse.Response.parseDelimitedFrom(new ByteBufferInputStream(payload));
-                if (!SqlResponse.Response.ResponseCase.RESULT_ONLY.equals(response.getResponseCase())) {
-                    // FIXME log error message
-                    throw new IOException("response type is inconsistent with the request type");
-                }
-                detailResponseCache.set(response.getResultOnly());
+        public ExecuteResult process(ByteBuffer payload) throws IOException, ServerException, InterruptedException {
+            if (responseCache.get() == null) {
+                responseCache.set(SqlResponse.Response.parseDelimitedFrom(new ByteBufferInputStream(payload)));
             }
-            var detailResponse = detailResponseCache.get();
-            LOG.trace("receive (execute load): {}", detailResponse); //$NON-NLS-1$
-            if (SqlResponse.ResultOnly.ResultCase.ERROR.equals(detailResponse.getResultCase())) {
-                var errorResponse = detailResponse.getError();
-                throw SqlServiceException.of(SqlServiceCode.valueOf(errorResponse.getCode()), errorResponse.getDetail());
+            var response = responseCache.get();
+            switch (response.getResponseCase()) {
+                case EXECUTE_RESULT:
+                    var detailResponse = response.getExecuteResult();
+                    LOG.trace("receive (ExecuteResult): {}", detailResponse); //$NON-NLS-1$
+                    if (SqlResponse.ExecuteResult.ResultCase.ERROR.equals(detailResponse.getResultCase())) {
+                        var errorResponse = detailResponse.getError();
+                        throw SqlServiceException.of(SqlServiceCode.valueOf(errorResponse.getCode()), errorResponse.getDetail());
+                    }
+                    return new ExecuteResultAdapter(detailResponse.getSuccess());
+                case RESULT_ONLY:
+                    var resultOnlyResponse = response.getResultOnly();
+                    LOG.trace("receive (ResultOnly): {}", resultOnlyResponse); //$NON-NLS-1$
+                    if (SqlResponse.ResultOnly.ResultCase.ERROR.equals(resultOnlyResponse.getResultCase())) {
+                        var errorResponse = resultOnlyResponse.getError();
+                        throw SqlServiceException.of(SqlServiceCode.valueOf(errorResponse.getCode()), errorResponse.getDetail());
+                    }
+                    return new ExecuteResultAdapter();
             }
-            return null;
+            throw new IOException("response type is inconsistent with the request type");
         }
     }
 
     @Override
-    public FutureResponse<Void> send(
+    public FutureResponse<ExecuteResult> send(
             @Nonnull SqlRequest.ExecuteLoad request) throws IOException {
         Objects.requireNonNull(request);
         LOG.trace("send (execute load): {}", request); //$NON-NLS-1$

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
@@ -38,6 +38,7 @@ import com.tsurugidb.tsubakuro.sql.StatementMetadata;
 import com.tsurugidb.tsubakuro.sql.TableList;
 import com.tsurugidb.tsubakuro.sql.TableMetadata;
 import com.tsurugidb.tsubakuro.sql.Transaction;
+import com.tsurugidb.tsubakuro.sql.ExecuteResult;
 import com.tsurugidb.tsubakuro.sql.io.StreamBackedValueInput;
 import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
@@ -423,11 +424,11 @@ public class SqlServiceStub implements SqlService {
                 new DescribeTableProcessor().asResponseProcessor());
     }
 
-    static class ExecuteProcessor implements MainResponseProcessor<Void> {
+    static class ExecuteProcessor implements MainResponseProcessor<ExecuteResult> {
         private final AtomicReference<SqlResponse.Response> responseCache = new AtomicReference<>();
 
         @Override
-        public Void process(ByteBuffer payload) throws IOException, ServerException, InterruptedException {
+        public ExecuteResult process(ByteBuffer payload) throws IOException, ServerException, InterruptedException {
             if (responseCache.get() == null) {
                 responseCache.set(SqlResponse.Response.parseDelimitedFrom(new ByteBufferInputStream(payload)));
             }
@@ -440,7 +441,7 @@ public class SqlServiceStub implements SqlService {
                         var errorResponse = detailResponse.getError();
                         throw SqlServiceException.of(SqlServiceCode.valueOf(errorResponse.getCode()), errorResponse.getDetail());
                     }
-                    return null;
+                    return new ExecuteResultAdapter(detailResponse.getSuccess());
                 case RESULT_ONLY:
                     var resultOnlyResponse = response.getResultOnly();
                     LOG.trace("receive (ResultOnly): {}", resultOnlyResponse); //$NON-NLS-1$
@@ -455,7 +456,7 @@ public class SqlServiceStub implements SqlService {
     }
 
     @Override
-    public FutureResponse<Void> send(
+    public FutureResponse<ExecuteResult> send(
             @Nonnull SqlRequest.ExecuteStatement request) throws IOException {
         Objects.requireNonNull(request);
         LOG.trace("send (execute statement): {}", request); //$NON-NLS-1$
@@ -468,7 +469,7 @@ public class SqlServiceStub implements SqlService {
     }
 
     @Override
-    public FutureResponse<Void> send(
+    public FutureResponse<ExecuteResult> send(
             @Nonnull SqlRequest.ExecutePreparedStatement request) throws IOException {
         Objects.requireNonNull(request);
         LOG.trace("send (execute prepared statement): {}", request); //$NON-NLS-1$

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
@@ -190,7 +190,7 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
-    public FutureResponse<Void> executeLoad(
+    public FutureResponse<ExecuteResult> executeLoad(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters,
             @Nonnull Collection<? extends Path> files) throws IOException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
@@ -25,6 +25,7 @@ import com.tsurugidb.tsubakuro.sql.ResultSet;
 import com.tsurugidb.tsubakuro.sql.SqlService;
 import com.tsurugidb.tsubakuro.sql.SqlServiceException;
 import com.tsurugidb.tsubakuro.sql.Transaction;
+import com.tsurugidb.tsubakuro.sql.ExecuteResult;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
 import com.tsurugidb.tsubakuro.util.Lang;
 import com.tsurugidb.tsubakuro.util.ServerResource;
@@ -64,7 +65,7 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
-    public FutureResponse<Void> executeStatement(@Nonnull String source) throws IOException {
+    public FutureResponse<ExecuteResult> executeStatement(@Nonnull String source) throws IOException {
         Objects.requireNonNull(source);
         if (cleanuped.get()) {
             throw new IOException("transaction already closed");
@@ -88,7 +89,7 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
-    public FutureResponse<Void> executeStatement(
+    public FutureResponse<ExecuteResult> executeStatement(
             @Nonnull PreparedStatement statement,
             @Nonnull Collection<? extends SqlRequest.Parameter> parameters) throws IOException {
         Objects.requireNonNull(statement);

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/Load.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/Load.java
@@ -14,6 +14,7 @@ import com.tsurugidb.tsubakuro.sql.PreparedStatement;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 import com.tsurugidb.tsubakuro.sql.TableMetadata;
 import com.tsurugidb.tsubakuro.sql.Transaction;
+import com.tsurugidb.tsubakuro.sql.ExecuteResult;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
 import com.tsurugidb.tsubakuro.util.ServerResource;
 import com.tsurugidb.tsubakuro.util.Timeout;
@@ -64,7 +65,7 @@ public class Load implements ServerResource {
      * @throws IOException if I/O error was occurred
      * @see Transaction#executeLoad(PreparedStatement, Collection, Collection)
      */
-    public FutureResponse<Void> submit(
+    public FutureResponse<ExecuteResult> submit(
             @Nonnull Transaction transaction,
             @Nonnull Collection<? extends Path> files) throws IOException {
         Objects.requireNonNull(transaction);
@@ -80,7 +81,7 @@ public class Load implements ServerResource {
      * @throws IOException if I/O error was occurred
      * @see #submit(Transaction, Collection)
      */
-    public FutureResponse<Void> submit(
+    public FutureResponse<ExecuteResult> submit(
             @Nonnull Transaction transaction,
             @Nonnull Path... files) throws IOException {
         Objects.requireNonNull(transaction);
@@ -96,7 +97,7 @@ public class Load implements ServerResource {
      * @throws IOException if I/O error was occurred
      * @see SqlClient#executeLoad(PreparedStatement, Collection, Collection)
      */
-    public FutureResponse<Void> submit(
+    public FutureResponse<ExecuteResult> submit(
             @Nonnull SqlClient client,
             @Nonnull Collection<? extends Path> files) throws IOException {
         Objects.requireNonNull(client);
@@ -112,7 +113,7 @@ public class Load implements ServerResource {
      * @throws IOException if I/O error was occurred
      * @see #submit(SqlClient, Collection)
      */
-    public FutureResponse<Void> submit(
+    public FutureResponse<ExecuteResult> submit(
             @Nonnull SqlClient client,
             @Nonnull Path... files) throws IOException {
         Objects.requireNonNull(client);

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
@@ -326,7 +326,7 @@ class TransactionImplTest {
                                               .build(),
                                               new SqlService() {
                 @Override
-                public FutureResponse<Void> send(SqlRequest.ExecuteLoad request) throws IOException {
+                public FutureResponse<ExecuteResult> send(SqlRequest.ExecuteLoad request) throws IOException {
                     count.incrementAndGet();
                     assertEquals(100, request.getTransactionHandle().getHandle());
                     assertEquals(200, request.getPreparedStatementHandle().getHandle());

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
@@ -88,7 +88,7 @@ class TransactionImplTest {
                                               .build(),
                                               new SqlService() {
                 @Override
-                public FutureResponse<Void> send(SqlRequest.ExecuteStatement request) throws IOException {
+                public FutureResponse<ExecuteResult> send(SqlRequest.ExecuteStatement request) throws IOException {
                     count.incrementAndGet();
                     assertEquals(100, request.getTransactionHandle().getHandle());
                     assertEquals("SELECT 100", request.getSql());
@@ -118,7 +118,7 @@ class TransactionImplTest {
                                               .build(),
                                               new SqlService() {
                 @Override
-                public FutureResponse<Void> send(SqlRequest.ExecutePreparedStatement request) throws IOException {
+                public FutureResponse<ExecuteResult> send(SqlRequest.ExecutePreparedStatement request) throws IOException {
                     count.incrementAndGet();
                     assertEquals(100, request.getTransactionHandle().getHandle());
                     assertEquals(100, request.getPreparedStatementHandle().getHandle());

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilderTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilderTest.java
@@ -17,6 +17,7 @@ import com.tsurugidb.tsubakuro.sql.impl.TableMetadataAdapter;
 import com.tsurugidb.tsubakuro.sql.PreparedStatement;
 import com.tsurugidb.tsubakuro.sql.SqlClient;
 import com.tsurugidb.tsubakuro.sql.Transaction;
+import com.tsurugidb.tsubakuro.sql.ExecuteResult;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
 import com.tsurugidb.sql.proto.SqlCommon;
 import com.tsurugidb.sql.proto.SqlRequest;
@@ -71,7 +72,7 @@ class LoadBuilderTest {
 
     private final Transaction transaction = new Transaction() {
         @Override
-        public FutureResponse<Void> executeLoad(
+        public FutureResponse<ExecuteResult> executeLoad(
                 PreparedStatement statement,
                 Collection<? extends SqlRequest.Parameter> parameters,
                 Collection<? extends Path> files) throws IOException {
@@ -346,7 +347,7 @@ class LoadBuilderTest {
 
     private final SqlClient sqlClient = new SqlClient() {
         @Override
-        public FutureResponse<Void> executeLoad(
+        public FutureResponse<ExecuteResult> executeLoad(
                 PreparedStatement statement,
                 Collection<? extends SqlRequest.Parameter> parameters,
                 Collection<? extends Path> files) throws IOException {


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/393
The return type of Transaction.executeStatement(), Transaction.executeLoad(), and SqlClient.executeLoad() have changed from Void to ExecuteResult.
