### PR TITLE
Fix javadoc param etc

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/BackgroundFutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/BackgroundFutureResponse.java
@@ -45,7 +45,6 @@ public class BackgroundFutureResponse<V> implements FutureResponse<V>, Runnable 
      * Creates a new instance.
      * @param delegate the decoration target
      * @param mapper the response mapper
-     * @param closeHandler handles {@link #close()} was invoked
      */
     public BackgroundFutureResponse(
             @Nonnull FutureResponse<? extends Response> delegate,

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
@@ -47,7 +47,6 @@ public class ForegroundFutureResponse<V> implements FutureResponse<V> {  // FIXM
      * Creates a new instance.
      * @param delegate the decoration target
      * @param mapper the response mapper
-     * @param closeHandler handles {@link #close()} was invoked
      */
     public ForegroundFutureResponse(
             @Nonnull FutureResponse<? extends Response> delegate,

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Response.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Response.java
@@ -61,7 +61,6 @@ public interface Response extends ServerResource {
      * @throws IOException if I/O error was occurred while opening the sub-responses
      * @throws ServerException if server error was occurred while opening the sub-responses
      * @throws InterruptedException if interrupted by other threads while opening the sub-responses
-     * @see #getSubResponseIds()
      */
     default InputStream openSubResponse(String id) throws NoSuchElementException, IOException, ServerException, InterruptedException {
         throw new UnsupportedOperationException();
@@ -81,7 +80,6 @@ public interface Response extends ServerResource {
      * @throws ServerException if server error was occurred while opening the sub-responses
      * @throws InterruptedException if interrupted by other threads while opening the sub-responses
      * @throws TimeoutException if the wait time out;
-     * @see #getSubResponseIds()
      */
     default InputStream openSubResponse(String id, long timeout, TimeUnit unit)
             throws NoSuchElementException, IOException, ServerException, InterruptedException, TimeoutException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreService.java
@@ -126,7 +126,7 @@ public interface DatastoreService extends ServerResource {
      * @param time the expiration time from now
      * @param unit the time unit of expiration time
      * @return the future response of the request;
-     *     it will raise {@link CoreServiceException} if request was failure
+     *     it will raise {@link ServerException} if request was failure
      * @throws IOException if I/O error was occurred while sending request
      */
     default FutureResponse<Void> updateExpirationTime(long time, TimeUnit unit) throws IOException {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -129,7 +129,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * Please split the parameter table and execute {@link #batch(PreparedStatement, Collection) batch()} for the
      * individual fragment of the parameter table.
      * For large parameter tables, please consider to use
-     * {@link #load(PreparedStatement, Collection, Collection) load()} instead.
+     * {@link #executeLoad(PreparedStatement, Collection, Collection) load()} instead.
      * </p>
      * @param statement the prepared statement to execute for each 1-D parameter set
      * @param parameterTable 2-D parameter table (list of 1-D parameter set) for place-holders in the prepared statement
@@ -275,7 +275,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
     * Returns occurred error in the target transaction, only if the transaction has been accidentally aborted.
     * @return the future response of the error information:
     * if the transaction will have been accidentally aborted, this provides the occurred error information.
-    * otherwise, the transaction is running, successfully committed, or manually aborted, then this will provide {@code null
+    * otherwise, the transaction is running, successfully committed, or manually aborted, then this will provide {@code null}
     * The returned object may <b>raise exception</b> if this operation occurs a new error in the server side.
     * @throws IOException if I/O error was occurred while sending request
     */


### PR DESCRIPTION
Javadocで、警告が出ていた箇所を直しました。
APIのコメントが絡むので、ご確認をよろしくお願いいたします。

・BackgroundFutureResponse.java、ForegroundFutureResponse.java
　存在しない引数の解説を消しました。
・wire/Response.java
　存在しないメソッドへの参照を消しました。問題ないでしょうか。
・datastore/DatastoreService.java
　例外クラス名を直しました。
　以下の記述から、ServerExceptionにしましたが、問題ないでしょうか。
　https://github.com/project-tsurugi/tsubakuro/blob/master/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/FutureResponse.java#L38
・sql/Transaction.java
　存在しないメソッドを、それに近い executeLoad() に直しました。問題ないでしょうか。
・sql/Transaction.java
　``{@code null`` に右カッコをつけました。