### PR TITLE
fix javadoc (causes warn/errors when publish or using java17)

### DIFF
--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceException.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceException.java
@@ -14,6 +14,9 @@ public class DebugServiceException extends ServerException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * the diagnostic code
+     */
     private final DebugServiceCode code;
 
     /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceCode.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceCode.java
@@ -58,7 +58,9 @@ public enum KvsServiceCode implements DiagnosticCode {
 
     /**
      * transaction operation met an user-defined error.
-     * @details this code is returned only from transaction_exec() and transaction_commit()
+     * <p>
+     * this code is returned only from transaction_exec() and transaction_commit()
+     * </p>
      */
     USER_ERROR(106),
 
@@ -83,40 +85,44 @@ public enum KvsServiceCode implements DiagnosticCode {
     NOT_IMPLEMENTED(110),
 
     /**
-     * @brief the operation is not valid
+     * the operation is not valid
      */
     ILLEGAL_OPERATION(111),
 
     /**
-     * @brief the operation conflicted on write preserve
+     * the operation conflicted on write preserve
      */
     CONFLICT_ON_WRITE_PRESERVE(112),
 
     /**
-     * @brief long tx issued write operation without preservation
+     * long tx issued write operation without preservation
      */
     WRITE_WITHOUT_WRITE_PRESERVE(114),
 
     /**
-     * @brief transaction is inactive
-     * @details transaction is inactive since it's already committed or aborted. The request is failed.
+     * transaction is inactive
+     * <p>
+     * transaction is inactive since it's already committed or aborted. The request is failed.
+     * </p>
      */
     INACTIVE_TRANSACTION(115),
 
     /**
-     * @brief requested operation is blocked by concurrent operation
-     * @details the request cannot be fulfilled due to the operation concurrently executed by other transaction.
+     * requested operation is blocked by concurrent operation
+     * <p>
+     * the request cannot be fulfilled due to the operation concurrently executed by other transaction.
      * After the blocking transaction completes, re-trying the request may lead to different result.
+     * </p>
      */
     BLOCKED_BY_CONCURRENT_OPERATION(116),
 
     /**
-     * @brief reached resource limit and request could not be accomplished
+     * reached resource limit and request could not be accomplished
      */
     RESOURCE_LIMIT_REACHED(117),
 
     /**
-     * @brief key length passed to the API is invalid
+     * key length passed to the API is invalid
      */
     INVALID_KEY_LENGTH(118),
 

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceException.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceException.java
@@ -14,6 +14,9 @@ public class KvsServiceException extends ServerException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * the diagnostic code
+     */
     private final KvsServiceCode code;
 
     /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Values.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Values.java
@@ -23,7 +23,7 @@ import com.tsurugidb.kvs.proto.KvsData;
 /**
  * Utilities for values.
  *
- * <h3> Value type mapping </h3>
+ * <p><b>Value type mapping</b></p>
  *
  * <table>
  *   <caption> value type mapping </caption>

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsService.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsService.java
@@ -162,11 +162,14 @@ public interface KvsService extends ServerResource {
 
     /**
      * Requests empty message to KVS service.
+     * <p>
+     * NOTE: this method is designed just only for benchmark or debug.
+     * </p>
      * @return the future response of the request,
      *      which may raise error if the request was failed.
      *      If the request was succeeded, future will returns an operation result object
      * @throws IOException if I/O error was occurred while sending the request
-     * @note this method is designed just only for benchmark or debug.
+     *
      */
     default FutureResponse<Void> request() throws IOException {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
sharksfinからコピペしたコメントに、doxygen独自のタグを利用しているものがありました。通常のビルドではこれが警告やエラーにならず、見逃していました。
javadocにすると、その部分の記述内容が空欄になっていました。
それらをjavadoc形式に直し、正しく記述が表示されることを確認しました。

また、java15以降では、Serializableなクラスについては、privateなフィールドについてもコメントを書かなければならなくなったようです。
現在java11を利用していますが、ついでなので、コメントを追加しておきました。