### PR TITLE
fix javadoc errors (all warnings of missing comment still remain)

### DIFF
--- a/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProvider.java
+++ b/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProvider.java
@@ -173,6 +173,7 @@ public class MockTicketProvider implements TicketProvider {
      * </p>
      * <p>
      * The returned ticket will have the following properties:
+     * </p>
      *
      * <ul>
      * <li>
@@ -187,8 +188,6 @@ public class MockTicketProvider implements TicketProvider {
      *      The individual tokens will have the expiration date based on the time which is set in {@link #withIssuedAt(Instant)}.
      * </li>
      * </ul>
-     *
-     * </p>
      * @see #withUser(String, String)
      * @see #withRefreshExpiration(long, TimeUnit)
      * @see #withAccessExpiration(long, TimeUnit)

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredential.java
@@ -24,13 +24,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * <p>
  * Each credential file is JSON formatted and has the following fields:
+ * </p>
  * <ul>
  * <li> {@code "user"} - {@link #getEncryptedName() encrypted user name} </li>
  * <li> {@code "user"} - {@link #getEncryptedPassword() encrypted password} </li>
  * </ul>
  *
  * Each field value will be encrypted using public key file.
- * </p>
  */
 public class FileCredential implements Credential {
 

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/FutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/FutureResponse.java
@@ -67,21 +67,19 @@ public interface FutureResponse<V> extends ServerResource {
      * <p>
      * Developers should use this method instead of {@link #get()}, unless there is some special reason.
      * This will avoid like as the following ugly code
-<pre>
-try (
+     * </p>
+<pre>{@code try (
     FutureResponse<Resource> future = send(...);
     Resource resource = future.get();
 ) {
     ...
 }
-</pre>
+}</pre>
      * Using {@link #await()}, it can be rewritten as follows:
-<pre>
-try (Resource resource = send(...).await()) {
+<pre>{@code try (Resource resource = send(...).await()) {
     ...
 }
-</pre>
-     * </p>
+}</pre>
      * @return the response
      * @throws IOException if exception was occurred while communicating to the server
      * @throws ServerException if exception was occurred while processing the request in the server
@@ -107,7 +105,7 @@ try (Resource resource = send(...).await()) {
      * @throws ServerException if exception was occurred while processing the request in the server
      * @throws InterruptedException if interrupted from other threads while waiting for response
      * @throws TimeoutException if the wait time out
-     * @see {@link #get(long, TimeUnit)}
+     * @see #get(long, TimeUnit)
      */
     default V await(long timeout, TimeUnit unit) throws IOException, ServerException, InterruptedException, TimeoutException {
         try (var self = this) {

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoader.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoader.java
@@ -217,6 +217,7 @@ public class JsonPlanGraphLoader implements PlanGraphLoader {
          * </p>
          * <p>
          * {@link JsonPlanGraphLoader} decides whether to keep individual operators as follows:
+         * </p>
          * <ol>
          * <li>
          * First, each operator which kind is in {@link #withExcludeOperators(Collection) exclude list} is removed.
@@ -231,7 +232,6 @@ public class JsonPlanGraphLoader implements PlanGraphLoader {
          * Otherwise, all operators are filtered out.
          * </li>
          * </ol>
-         * </p>
          * @param filter the node filter, or {@code null} to use the default filter
          * @return this
          */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Backup.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Backup.java
@@ -19,9 +19,8 @@ import com.tsurugidb.tsubakuro.util.ServerResource;
  * Note that, you can change directory hierarchy of individual files.
  * </p>
  *
- * <h3>example snippet</h3>
-<pre>
-Path destination = Paths.get("/path/to/backup-target");
+ * <p><b>example snippet</b></p>
+<pre>{@code Path destination = Paths.get("/path/to/backup-target");
 try (Backup backup = ...) {
     for (Path source : backup) {
         // extend the expiration time
@@ -31,7 +30,7 @@ try (Backup backup = ...) {
         Files.copy(source, destination.resolve(source.getFileName()))
     }
 }
-</pre>
+}</pre>
  * @see DatastoreClient#beginBackup()
  */
 public interface Backup extends ServerResource, Iterable<Path> {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupDetail.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupDetail.java
@@ -14,9 +14,8 @@ import com.tsurugidb.tsubakuro.util.ServerResource;
 /**
  * Represents detail backup information.
  *
- * <h3>example snippet</h3>
-<pre>
-Session session = ...;
+ * <p><b>example snippet</b></p>
+<pre>{@code Session session = ...;
 Path destination = ...;
 try (
     var client = DatastoreClient.attach(session);
@@ -41,7 +40,7 @@ try (
         backup.keepAlive();
     }
 }
-</pre>
+}</pre>
  * @see Backup
  * @see DatastoreClient#beginBackup(BackupType)
  */
@@ -101,11 +100,11 @@ public interface BackupDetail extends ServerResource {
      * </p>
      * <p>
      * Ordinary, the datastore will decide the configuration ID using the following elements:
+     * </p>
      * <ul>
      * <li> data layout in file </li>
      * <li> path layout on file system </li>
      * </ul>
-     * </p>
      * @return the configuration ID
      */
     String getConfigurationId();

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSet.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSet.java
@@ -22,7 +22,7 @@ public interface ResultSet extends RelationCursor {
     /**
      * Get a FutureResponse of the response returned from the SQL service
      * @return a FutureResponse of SqlResponse.ResultOnly indicate whether the SQL service has successfully completed processing or not
-     * @deprecated FutureResponse<Void> is checked at next() and/or close(), thus it is unnecessary to provide FutureResponse<Void> to tsubakuro's clinets
+     * @deprecated {@code FutureResponse<Void>} is checked at next() and/or close(), thus it is unnecessary to provide {@code FutureResponse<Void>} to tsubakuro's clinets
      */
     @Deprecated
     default FutureResponse<Void> getResponse() {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
@@ -43,7 +43,7 @@ public interface SqlClient extends ServerResource {
 
     /**
      * Starts a new transaction.
-     * The consequence of close() call of the returned FutureResponse<Transaction> is undefined, 
+     * The consequence of close() call of the returned {@code FutureResponse<Transaction>} is undefined,
      * if the close() is called without get() the Transaction object.
      * @param option the transaction option
      * @return a future response of transaction object
@@ -73,7 +73,7 @@ public interface SqlClient extends ServerResource {
 
     /**
      * Prepares a SQL statement.
-     * The consequence of close() call of the returned FutureResponse<PreparedStatement> is undefined, 
+     * The consequence of close() call of the returned {@code FutureResponse<PreparedStatement>} is undefined,
      * if the close() is called without get() the PreparedStatement object.
      * @param source the SQL statement text (may includes place-holders)
      * @param placeholders the place-holders in the statement text
@@ -89,7 +89,7 @@ public interface SqlClient extends ServerResource {
 
     /**
      * Retrieves execution plan of the statement.
-     * The consequence of close() call of the returned FutureResponse<StatementMetadata> is undefined, 
+     * The consequence of close() call of the returned {@code FutureResponse<StatementMetadata>} is undefined,
      * if the close() is called without get() the StatementMetadata object.
      * @param source the SQL statement text
      * @return a future response of statement metadata
@@ -118,7 +118,7 @@ public interface SqlClient extends ServerResource {
 
     /**
      * Retrieves execution plan of the statement.
-     * The consequence of close() call of the returned FutureResponse<StatementMetadata> is undefined, 
+     * The consequence of close() call of the returned {@code FutureResponse<StatementMetadata>} is undefined,
      * if the close() is called without get() the StatementMetadata object.
      * @param statement the prepared statement
      * @param parameters parameter list for place-holders in the prepared statement
@@ -134,7 +134,7 @@ public interface SqlClient extends ServerResource {
 
     /**
      * Retrieves metadata for a table.
-     * The consequence of close() call of the returned FutureResponse<TableMetadata> is undefined, 
+     * The consequence of close() call of the returned {@code FutureResponse<TableMetadata>} is undefined,
      * if the close() is called without get() the TableMetadata object.
      * @param tableName the target table name
      * @return a future response of table metadata
@@ -149,11 +149,11 @@ public interface SqlClient extends ServerResource {
      * Executes a load action out side transaction context.
      * <p>
      * This operation performs like as following:
+     * </p>
      * <ol>
      *   <li> extracts each row from the input dump files </li>
      *   <li> perform the statement for every rows, with substituting place-holders with the row data </li>
      * </ol>
-     * </p>
      * @param statement the prepared statement to execute
      * @param parameters parameter list for place-holders in the prepared statement.
      *      parameter can refer the column on the input dump file, by specifying

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -191,11 +191,11 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * Executes a load action.
      * <p>
      * This operation performs like as following:
+     * </p>
      * <ol>
      *   <li> extracts each row from the input dump files </li>
      *   <li> perform the statement for every rows, with substituting place-holders with the row data </li>
      * </ol>
-     * </p>
      * @param statement the prepared statement to execute
      * @param parameters parameter list for place-holders in the prepared statement.
      *      parameter can refer the column on the input dump file, by specifying
@@ -219,11 +219,11 @@ public interface Transaction extends ServerResourceNeedingDisposal {
      * Executes a load action.
      * <p>
      * This operation performs like as following:
+     * </p>
      * <ol>
      *   <li> extracts each row from the input dump files </li>
      *   <li> perform the statement for every rows, with substituting place-holders with the row data </li>
      * </ol>
-     * </p>
      * @param statement the prepared statement to execute
      * @param parameters parameter list for place-holders in the prepared statement.
      *      parameter can refer the column on the input dump file, by specifying

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java
@@ -27,9 +27,10 @@ import com.tsurugidb.tsubakuro.sql.io.DateTimeInterval;
  * This helps to build a SQL type representation from the Java types.
  * </p>
  *
- * <h3>type mapping rule</h3>
+ * <p><b>Type mapping rule</b></p>
  *
  * <table>
+ *   <caption> type mapping rule </caption>
  *   <thead>
  *     <tr>
  *       <th> SQL type </th>

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Relation.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Relation.java
@@ -238,14 +238,13 @@ public final class Relation {
      * <p>
      * The first dimension represents individual elements of rows.
      * This method is equivalent to the following:
-<pre>
-// converts each elements into rows
+<pre>{@code // converts each elements into rows
 List<Row> rows = of(Arrays.stream(values)
     .map(it -> row(it)
     .collect(Collectors.toList());
 // builds a relation
 return of(rows);
-</pre>
+}</pre>
      *
      * </p>
      * <p>


### PR DESCRIPTION
通常のビルドでは問題にならないものの
・``./gradlew clean publishMavenJavaPublicationToMavenLocal -PmavenLocal ``するとエラーや警告が出る（手元では再現できず）
・java17を使う設定にして ``./gradlew javadoc``するとエラーや警告が出る
javadocコメントが多数ありました。
このうち、エラーとなっている箇所について、すべて修正しました。

残っているのは「コメントが書かれていない」警告だけで、modules/sessionに24箇所です。
protoの自動生成ソースに対する警告は、別途設定で対処する予定です。

なお、javadoc生成エラーの原因は主に以下でした。
・``<p>...<ul>...</ul></p>``の書き方は厳密にはだめらしく、``<p>...</p><ul>...</ul>``に直しました。
・通常の解説コメント中に``List<V>`` などと書くと、``V``というタグがないと言われるので、``{@code List<V>}``などに直しました。
・同じくコード例などで、``<pre> List<V> = func(...); </pre>``などと書くとエラーになるので、``<pre>{@code List<V> ... }</pre>``に直しました。
なお、``{@code ``のあとに改行してからコード例を書き出すと、できたHTMLに余計な空行が入ってしまったため、``<pre>{@code `` 直後に（改行せず）コード例1行目を置きました。
また、``<V>``が使われていないコード例についても、``{@code }``くくりを念の為追加しておきました。
・``@see``のあとに``{@link #func(param)}``と書くと予期しないコンテンツエラーとなるので、``{@link }``なしで``@see #func(param)``に直しました

あわせて、Java17では出るエラーも直しました。
・コメント中に``<h3>..</h3>``タグを使うとエラーになった(``<h1>``がないせい？）ので、``<p><b>...</b></p>``に直しました。
・``<table>``に``<caption>``がないとエラーになったので、適宜追加しました。