### PR TITLE
Revise build.gradle 231124

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -67,7 +67,7 @@ jar {
 task writeVersion(type: WriteProperties) {
     description 'generate version file to META-INF/tsurugidb/{project.name}.properties'
     inputs.property('Build-Revision', buildRevision)
-    outputFile "${project.buildDir}/generated/version/META-INF/tsurugidb/${project.name}.properties"
+    destinationFile = file("${project.buildDir}/generated/version/META-INF/tsurugidb/${project.name}.properties")
     properties (
         'Build-Timestamp': buildTimestamp,
         'Build-Revision' : buildRevision,

--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -47,7 +47,11 @@ spotbugsMain {
 spotbugsTest.enabled = false
 checkstyleTest.enabled = false
 
-javadoc.failOnError = false
+javadoc {
+    failOnError = true
+    exclude "**/proto/**"
+    options.addStringOption('Xdoclint', '-quiet')
+}
 
 jar {
     manifest.attributes (

--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -31,10 +31,15 @@ checkstyle {
 checkstyleMain.exclude '**/proto/*.java'
 
 spotbugsMain {
+    onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
     reports {
         xml {
             enabled = true
             destination = file("$buildDir/reports/spotbugs/main/spotbugs.xml")
+        }
+        html {
+            enabled = true
+            destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
         }
     }
 }

--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -15,8 +15,11 @@ java {
 }
 
 dependencies {
-    testImplementation(platform('org.junit:junit-bom:5.7.1'))
-    testImplementation('org.junit.jupiter:junit-jupiter')
+    api 'com.google.code.findbugs:jsr305:3.0.2'
+    api 'org.slf4j:slf4j-api:1.7.36'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 checkstyle {

--- a/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-conventions.gradle
@@ -28,6 +28,7 @@ checkstyle {
         maxWarnings = 0
     }
 }
+checkstyleMain.exclude '**/proto/*.java'
 
 spotbugsMain {
     reports {

--- a/modules/auth-http/build.gradle
+++ b/modules/auth-http/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'tsubakuro.java-library-conventions'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(':tsubakuro-session')
 

--- a/modules/auth-http/build.gradle
+++ b/modules/auth-http/build.gradle
@@ -9,15 +9,8 @@ repositories {
 dependencies {
     api project(':tsubakuro-session')
 
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.auth0:java-jwt:3.19.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 test {

--- a/modules/auth-mock/build.gradle
+++ b/modules/auth-mock/build.gradle
@@ -8,12 +8,4 @@ repositories {
 
 dependencies {
     api project(':tsubakuro-session')
-
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/modules/auth-mock/build.gradle
+++ b/modules/auth-mock/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'tsubakuro.java-library-conventions'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(':tsubakuro-session')
 }

--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -3,12 +3,8 @@ plugins {
 }
 
 dependencies {
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-
-    api 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    testImplementation 'org.slf4j:slf4j-nop:1.7.32'
 
     api project(':tsubakuro-proto')
 }

--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
+    api project(':tsubakuro-proto')
+
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-
-    api project(':tsubakuro-proto')
 }

--- a/modules/connector/build.gradle
+++ b/modules/connector/build.gradle
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    testImplementation 'org.slf4j:slf4j-nop:1.7.32'
-
     api project(':tsubakuro-common')
     api project(':tsubakuro-ipc')
     api project(':tsubakuro-stream')

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -12,27 +12,6 @@ test {
     useJUnitPlatform()
 }
 
-spotbugsMain {
-    onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
-//  excludeFilter = rootProject.file('config/spotbugs/exclude.xml')
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
-
-spotbugsTestFixtures {
-    onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
-
-spotbugsTest {
-    enabled = false
-}
-
 protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.8.0'

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 dependencies {
     api project(':tsubakuro-session')
 
-    api 'com.google.protobuf:protobuf-java:3.8.0'
+    api 'com.google.protobuf:protobuf-java:3.17.3'
 }
 test {
     useJUnitPlatform()

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -11,12 +11,6 @@ dependencies {
 test {
     useJUnitPlatform()
 }
-checkstyle {
-    sourceSets = [ sourceSets.main, sourceSets.testFixtures ]
-    if ('strict' == findProperty('checkMode')) {
-        maxWarnings = 0
-    }
-}
 
 spotbugsMain {
     onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -8,9 +8,6 @@ dependencies {
 
     api 'com.google.protobuf:protobuf-java:3.17.3'
 }
-test {
-    useJUnitPlatform()
-}
 
 protobuf {
     protoc {

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -14,19 +14,8 @@ repositories {
 
 dependencies {
     api project(':tsubakuro-session')
-    
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
+
     api 'com.google.protobuf:protobuf-java:3.8.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
-
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.1'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-    testImplementation(testFixtures(project(':tsubakuro-session')))
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 test {
     useJUnitPlatform()

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -1,10 +1,5 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
-    id 'java-library'
-    id 'java-test-fixtures'
-    id 'application'
-    id 'checkstyle'
-//    id 'com.github.spotbugs' version '4.7.1'
     id 'com.google.protobuf' version '0.8.18'
 }
 

--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -8,10 +8,6 @@ plugins {
     id 'com.google.protobuf' version '0.8.18'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(':tsubakuro-session')
 

--- a/modules/explain/build.gradle
+++ b/modules/explain/build.gradle
@@ -3,15 +3,8 @@ plugins {
 }
 
 dependencies {
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 task run(type: JavaExec) {

--- a/modules/ipc/build.gradle
+++ b/modules/ipc/build.gradle
@@ -4,10 +4,5 @@ plugins {
 }
 
 dependencies {
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-
-    api 'org.slf4j:slf4j-api:1.7.32'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.32'
-
     implementation project(':tsubakuro-common')
 }

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -13,27 +13,6 @@ test {
     useJUnitPlatform()
 }
 
-spotbugsMain {
-    onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
-//  excludeFilter = rootProject.file('config/spotbugs/exclude.xml')
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
-
-spotbugsTestFixtures {
-    onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
-
-spotbugsTest {
-    enabled = false
-}
-
 protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.8.0'

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -9,10 +9,6 @@ dependencies {
     api 'com.google.protobuf:protobuf-java:3.17.3'
 }
 
-test {
-    useJUnitPlatform()
-}
-
 protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.8.0'

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -15,18 +15,7 @@ repositories {
 dependencies {
     api project(':tsubakuro-session')
 
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
     api 'com.google.protobuf:protobuf-java:3.8.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.3'
-
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.1'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
-    testImplementation(testFixtures(project(':tsubakuro-session')))
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 test {

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -8,10 +8,6 @@ plugins {
     id 'com.google.protobuf' version '0.8.18'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(':tsubakuro-session')
 

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -13,13 +13,6 @@ test {
     useJUnitPlatform()
 }
 
-checkstyle {
-    sourceSets = [ sourceSets.main, sourceSets.testFixtures ]
-    if ('strict' == findProperty('checkMode')) {
-        maxWarnings = 0
-    }
-}
-
 spotbugsMain {
     onlyAnalyze = [ 'com.tsurugidb.tsubakuro.-' ]
 //  excludeFilter = rootProject.file('config/spotbugs/exclude.xml')

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -1,10 +1,5 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
-    id 'java-library'
-    id 'java-test-fixtures'
-    id 'application'
-    id 'checkstyle'
-//  id 'com.github.spotbugs' version '4.7.1'
     id 'com.google.protobuf' version '0.8.18'
 }
 

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 dependencies {
     api project(':tsubakuro-session')
 
-    api 'com.google.protobuf:protobuf-java:3.8.0'
+    api 'com.google.protobuf:protobuf-java:3.17.3'
 }
 
 test {

--- a/modules/proto/build.gradle
+++ b/modules/proto/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
-
     id 'com.google.protobuf' version '0.9.4'
 }
 

--- a/modules/proto/build.gradle
+++ b/modules/proto/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'tsubakuro.java-library-conventions'
 
-    id 'com.google.protobuf' version '0.8.18'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 dependencies {
@@ -32,4 +32,7 @@ spotbugsMain.enabled = false
 
 tasks.withType(com.google.protobuf.gradle.GenerateProtoTask){
     sourcesJar.dependsOn(generateProto)
+}
+sourcesJar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/modules/session/build.gradle
+++ b/modules/session/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 dependencies {
+    api project(':tsubakuro-common')
+
     api 'com.auth0:java-jwt:3.19.2'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.1'
-
-    api project(':tsubakuro-common')
 }
 
 compileJava {

--- a/modules/session/build.gradle
+++ b/modules/session/build.gradle
@@ -11,9 +11,13 @@ dependencies {
 }
 
 compileJava {
-    options.compilerArgs << '-Xlint:unchecked'
+    if ('lint:unchecked' == findProperty('lintMode')) {
+        options.compilerArgs << '-Xlint:unchecked'
+    }
 }
 
 compileTestJava {
-    options.compilerArgs << '-Xlint:unchecked'
+    if ('lint:unchecked' == findProperty('lintMode')) {
+        options.compilerArgs << '-Xlint:unchecked'
+    }
 }

--- a/modules/session/build.gradle
+++ b/modules/session/build.gradle
@@ -4,12 +4,8 @@ plugins {
 }
 
 dependencies {
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-
     api 'com.auth0:java-jwt:3.19.2'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.1'
-
-    testImplementation 'org.slf4j:slf4j-nop:1.7.32'
 
     api project(':tsubakuro-common')
 }

--- a/modules/stream/build.gradle
+++ b/modules/stream/build.gradle
@@ -5,8 +5,5 @@ plugins {
 dependencies {
     api 'com.google.code.findbugs:jsr305:3.0.2'
 
-    api 'org.slf4j:slf4j-api:1.7.32'
-    testImplementation 'org.slf4j:slf4j-nop:1.7.32'
-
     implementation project(':tsubakuro-common')
 }

--- a/modules/stream/build.gradle
+++ b/modules/stream/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-
     implementation project(':tsubakuro-common')
+
+    api 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/modules/stream/build.gradle
+++ b/modules/stream/build.gradle
@@ -5,5 +5,8 @@ plugins {
 dependencies {
     api 'com.google.code.findbugs:jsr305:3.0.2'
 
+    api 'org.slf4j:slf4j-api:1.7.32'
+    testImplementation 'org.slf4j:slf4j-nop:1.7.32'
+
     implementation project(':tsubakuro-common')
 }


### PR DESCRIPTION
各モジュールのbuild.gradleの設定を修正しました。
大原則として、共通設定を tsubakuro/buildSrc/.../tsubakuro.java-conventions.gradleに置き、各モジュールのbuild.gradleでの設定はすべて削除しました。
そのうえで、以下も行いました。

・checkstyleでprotobufの自動生成ソースを除外
・spotbugsでprotobufの自動生成ソースを除外＆HTML出力追加
・javadocでprotobufの自動生成ソースを除外、常に厳密チェックあり(publish作業時と同等）
・protobufに関わるモジュールをすべて最新バージョンに統一
・modules/session/build.gradleの-Xlint設定をオプションに変更（デフォルトはOFF）
・Gradle 9.0では削除予定の古い書き方を新しい書き方に変更
・その他、空行など、スタイル統一