### PR TITLE
delete unnecessary srcDir (causes file duplication in sourcesJar)

### DIFF
--- a/modules/proto/build.gradle
+++ b/modules/proto/build.gradle
@@ -9,9 +9,6 @@ dependencies {
 
 sourceSets {
     main {
-        java {
-            srcDir('build/generated/source/proto/main/java')
-        }
         proto {
             srcDir("src/main/protos")
         }
@@ -28,10 +25,3 @@ protobuf {
 
 checkstyleMain.enabled = false
 spotbugsMain.enabled = false
-
-tasks.withType(com.google.protobuf.gradle.GenerateProtoTask){
-    sourcesJar.dependsOn(generateProto)
-}
-sourcesJar {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}


### PR DESCRIPTION
protobufのpluginのバージョンアップで、自動生成ソースを明示的にソースフォルダとして指定しなくても良くなったようです。
指定してしまうと、暗黙に追加されたものとの二重登録になってしまい、sources.jarを作ると、同じファイルが二回含まれるて警告が出ていました。
そこで、明示的なソースフォルダ指定を消し、以前書き改めたときに警告回避のためにつけたduplicatesStrategyの設定も消しました。
あわせて、なくても動作に支障のないGenerateProtoTaskの設定も消しました。

参考：
https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.9.0
``
Added generated code to java SourceSet instead of only adding it to JavaCompile and related tasks. This should cause tasks like sourcesJar and javadoc to now include the generated code. You may need to exclude the generated code from linters
``