### PR TITLE
Add mock for tests

### DIFF
--- a/modules/debug/build.gradle
+++ b/modules/debug/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api project(':tsubakuro-session')
 
+    testImplementation(testFixtures(project(':tsubakuro-session')))
     api 'com.google.protobuf:protobuf-java:3.17.3'
 }
 

--- a/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStubTest.java
+++ b/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStubTest.java
@@ -1,0 +1,88 @@
+package com.tsurugidb.tsubakuro.debug.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.debug.proto.DebugRequest;
+import com.tsurugidb.debug.proto.DebugRequest.Request;
+import com.tsurugidb.debug.proto.DebugResponse;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.common.Session;
+import com.tsurugidb.tsubakuro.common.impl.SessionImpl;
+import com.tsurugidb.tsubakuro.debug.DebugServiceCode;
+import com.tsurugidb.tsubakuro.debug.DebugServiceException;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.mock.MockWire;
+import com.tsurugidb.tsubakuro.mock.RequestHandler;
+import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
+
+class DebugServiceStubTest {
+
+    private final MockWire wire = new MockWire();
+
+    private final Session session = new SessionImpl(wire);
+
+    @AfterEach
+    void tearDown() throws IOException, InterruptedException, ServerException {
+        session.close();
+    }
+
+    private static RequestHandler accepts(DebugRequest.Request.CommandCase command, RequestHandler next) {
+        return new RequestHandler() {
+            @Override
+            public Response handle(int serviceId, ByteBuffer request) throws IOException, ServerException {
+                Request message = DebugRequest.Request.parseDelimitedFrom(new ByteBufferInputStream(request));
+                assertEquals(command, message.getCommandCase());
+                return next.handle(serviceId, request);
+            }
+        };
+    }
+
+    private static DebugResponse.Void newVoid() {
+        return DebugResponse.Void.newBuilder()
+                .build();
+    }
+
+    private static DebugResponse.UnknownError newUnknown(String message) {
+        return DebugResponse.UnknownError.newBuilder()
+                .setMessage(message)
+                .build();
+    }
+
+    @Test
+    void send_Logging_Success() throws Exception {
+        wire.next(accepts(DebugRequest.Request.CommandCase.LOGGING,
+                RequestHandler.returns(DebugResponse.Logging.newBuilder()
+                        .setSuccess(newVoid())
+                        .build())));
+
+        var message = DebugRequest.Logging.newBuilder()
+                .build();
+        try (var delegate = new DebugServiceStub(session)) {
+            delegate.send(message).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Logging_UnknownError() throws Exception {
+        wire.next(RequestHandler.returns(DebugResponse.Logging.newBuilder()
+                .setUnknownError(newUnknown("UE"))
+                .build()));
+
+        var message = DebugRequest.Logging.newBuilder()
+                .build();
+        try (var delegate = new DebugServiceStub(session)) {
+            var e = assertThrows(DebugServiceException.class, () -> delegate.send(message).await());
+            assertEquals(DebugServiceCode.UNKNOWN, e.getDiagnosticCode());
+        }
+        assertFalse(wire.hasRemaining());
+    }
+}

--- a/modules/kvs/build.gradle
+++ b/modules/kvs/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api project(':tsubakuro-session')
 
+    testImplementation(testFixtures(project(':tsubakuro-session')))
     api 'com.google.protobuf:protobuf-java:3.17.3'
 }
 

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
@@ -1,34 +1,25 @@
 package com.tsurugidb.tsubakuro.kvs.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.kvs.proto.KvsRequest;
-import com.tsurugidb.kvs.proto.KvsRequest.Request;
 import com.tsurugidb.kvs.proto.KvsResponse;
-import com.tsurugidb.kvs.proto.KvsTransaction.Handle;
-import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
 import com.tsurugidb.tsubakuro.common.Session;
 import com.tsurugidb.tsubakuro.common.impl.SessionImpl;
 import com.tsurugidb.tsubakuro.exception.ServerException;
-import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
 import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
 import com.tsurugidb.tsubakuro.mock.MockWire;
 import com.tsurugidb.tsubakuro.mock.RequestHandler;
-import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
 
 class KvsServiceStubTest {
 
     private final MockWire wire = new MockWire();
-
     private final Session session = new SessionImpl(wire);
 
     @AfterEach
@@ -36,85 +27,11 @@ class KvsServiceStubTest {
         session.close();
     }
 
-    private static RequestHandler accepts(KvsRequest.Request.CommandCase command, RequestHandler next) {
-        return new RequestHandler() {
-            @Override
-            public Response handle(int serviceId, ByteBuffer request) throws IOException, ServerException {
-                Request req = KvsRequest.Request.parseDelimitedFrom(new ByteBufferInputStream(request));
-                assertEquals(command, req.getCommandCase());
-                return next.handle(serviceId, request);
-            }
-        };
-    }
-
-    private static KvsResponse.Void newVoid() {
-        return KvsResponse.Void.newBuilder()
-                .build();
-    }
-
-    private static KvsResponse.Error newError(int code, String req) {
-        return KvsResponse.Error.newBuilder()
-                .setCode(code)
-                .setDetail(req)
-                .build();
-    }
-
-    private static final KvsServiceCode ERR_CODE = KvsServiceCode.INVALID_ARGUMENT;
-    private static final String ERR_DETAIL = "error occured";
-
-    private static KvsResponse.Error newError() {
-        return newError(ERR_CODE.getCodeNumber(), ERR_DETAIL);
-    }
-
-    private static void checkException(KvsServiceException e) {
-        assertEquals(ERR_CODE, e.getDiagnosticCode());
-        assertTrue(e.getMessage().contains(ERR_CODE.getStructuredCode()));
-        assertTrue(e.getMessage().contains(ERR_DETAIL));
-    }
-
-    private static KvsResponse.Response newBegin(long systemId) {
-        return KvsResponse.Response.newBuilder().setBegin(
-                KvsResponse.Begin.newBuilder()
-                    .setSuccess(KvsResponse.Begin.Success.newBuilder()
-                        .setTransactionHandle(
-                                Handle.newBuilder().setSystemId(systemId).build())
-                        .build())
-                    .build())
-                .build();
-    }
-
-    private static KvsResponse.Response newRollback() {
-        return KvsResponse.Response.newBuilder().setRollback(
-                KvsResponse.Rollback.newBuilder()
-                .setSuccess(newVoid()).build()).build();
-    }
-
-    private static KvsResponse.Response newDispose() {
-        return KvsResponse.Response.newBuilder().setDisposeTransaction(
-                KvsResponse.DisposeTransaction.newBuilder()
-                .setSuccess(newVoid()).build()).build();
-    }
-
-    private static RequestHandler newAcceptBegin(long systemId) throws IOException {
-        return accepts(KvsRequest.Request.CommandCase.BEGIN,
-                RequestHandler.returns(newBegin(systemId)));
-    }
-
-    private static RequestHandler newAcceptRollback() throws IOException {
-        return accepts(KvsRequest.Request.CommandCase.ROLLBACK,
-                RequestHandler.returns(newRollback()));
-    }
-
-    private static RequestHandler newAcceptDispose() throws IOException {
-        return accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
-                RequestHandler.returns(newDispose()));
-    }
-
     @Test
     void send_Begin_Success() throws Exception {
-        wire.next(newAcceptBegin(1234L));
-        wire.next(newAcceptRollback());
-        wire.next(newAcceptDispose());
+        wire.next(StubUtils.newAcceptBegin(1234L));
+        wire.next(StubUtils.newAcceptRollback());
+        wire.next(StubUtils.newAcceptDispose());
 
         var req = KvsRequest.Begin.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
@@ -129,13 +46,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setBegin(
                         KvsResponse.Begin.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.Begin.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }
@@ -144,10 +61,10 @@ class KvsServiceStubTest {
     void send_Commit_Success() throws Exception {
         var res = KvsResponse.Response.newBuilder().setCommit(
                     KvsResponse.Commit.newBuilder()
-                        .setSuccess(newVoid())
+                        .setSuccess(StubUtils.newVoid())
                         .build())
                     .build();
-        wire.next(accepts(KvsRequest.Request.CommandCase.COMMIT,
+        wire.next(StubUtils.accepts(KvsRequest.Request.CommandCase.COMMIT,
                 RequestHandler.returns(res)));
 
         var req = KvsRequest.Commit.newBuilder().build();
@@ -162,13 +79,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setCommit(
                         KvsResponse.Commit.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.Commit.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }
@@ -177,10 +94,10 @@ class KvsServiceStubTest {
     void send_Rollback_Success() throws Exception {
         var res = KvsResponse.Response.newBuilder().setRollback(
                     KvsResponse.Rollback.newBuilder()
-                        .setSuccess(newVoid())
+                        .setSuccess(StubUtils.newVoid())
                         .build())
                     .build();
-        wire.next(accepts(KvsRequest.Request.CommandCase.ROLLBACK,
+        wire.next(StubUtils.accepts(KvsRequest.Request.CommandCase.ROLLBACK,
                 RequestHandler.returns(res)));
 
         var req = KvsRequest.Rollback.newBuilder().build();
@@ -195,13 +112,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setRollback(
                         KvsResponse.Rollback.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.Rollback.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }
@@ -214,7 +131,7 @@ class KvsServiceStubTest {
                                 KvsResponse.Put.Success.newBuilder().build())
                         .build())
                     .build();
-        wire.next(accepts(KvsRequest.Request.CommandCase.PUT,
+        wire.next(StubUtils.accepts(KvsRequest.Request.CommandCase.PUT,
                 RequestHandler.returns(res)));
 
         var req = KvsRequest.Put.newBuilder().build();
@@ -229,13 +146,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setPut(
                         KvsResponse.Put.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.Put.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }
@@ -248,7 +165,7 @@ class KvsServiceStubTest {
                                 KvsResponse.Get.Success.newBuilder().build())
                         .build())
                     .build();
-        wire.next(accepts(KvsRequest.Request.CommandCase.GET,
+        wire.next(StubUtils.accepts(KvsRequest.Request.CommandCase.GET,
                 RequestHandler.returns(res)));
 
         var req = KvsRequest.Get.newBuilder().build();
@@ -263,13 +180,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setGet(
                         KvsResponse.Get.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.Get.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }
@@ -278,10 +195,10 @@ class KvsServiceStubTest {
     void send_DisposeTransaction_Success() throws Exception {
         var res = KvsResponse.Response.newBuilder().setDisposeTransaction(
                     KvsResponse.DisposeTransaction.newBuilder()
-                        .setSuccess(newVoid())
+                        .setSuccess(StubUtils.newVoid())
                         .build())
                     .build();
-        wire.next(accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
+        wire.next(StubUtils.accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
                 RequestHandler.returns(res)));
 
         var req = KvsRequest.DisposeTransaction.newBuilder().build();
@@ -296,13 +213,13 @@ class KvsServiceStubTest {
         wire.next(RequestHandler.returns(
                 KvsResponse.Response.newBuilder().setDisposeTransaction(
                         KvsResponse.DisposeTransaction.newBuilder()
-                            .setError(newError())
+                            .setError(StubUtils.newError())
                             ).build()));
 
         var req = KvsRequest.DisposeTransaction.newBuilder().build();
         try (var delegate = new KvsServiceStub(session)) {
             var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
-            checkException(e);
+            StubUtils.checkException(e);
         }
         assertFalse(wire.hasRemaining());
     }

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
@@ -1,0 +1,309 @@
+package com.tsurugidb.tsubakuro.kvs.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.kvs.proto.KvsRequest;
+import com.tsurugidb.kvs.proto.KvsRequest.Request;
+import com.tsurugidb.kvs.proto.KvsResponse;
+import com.tsurugidb.kvs.proto.KvsTransaction.Handle;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.common.Session;
+import com.tsurugidb.tsubakuro.common.impl.SessionImpl;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
+import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
+import com.tsurugidb.tsubakuro.mock.MockWire;
+import com.tsurugidb.tsubakuro.mock.RequestHandler;
+import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
+
+class KvsServiceStubTest {
+
+    private final MockWire wire = new MockWire();
+
+    private final Session session = new SessionImpl(wire);
+
+    @AfterEach
+    void tearDown() throws IOException, InterruptedException, ServerException {
+        session.close();
+    }
+
+    private static RequestHandler accepts(KvsRequest.Request.CommandCase command, RequestHandler next) {
+        return new RequestHandler() {
+            @Override
+            public Response handle(int serviceId, ByteBuffer request) throws IOException, ServerException {
+                Request req = KvsRequest.Request.parseDelimitedFrom(new ByteBufferInputStream(request));
+                assertEquals(command, req.getCommandCase());
+                return next.handle(serviceId, request);
+            }
+        };
+    }
+
+    private static KvsResponse.Void newVoid() {
+        return KvsResponse.Void.newBuilder()
+                .build();
+    }
+
+    private static KvsResponse.Error newError(int code, String req) {
+        return KvsResponse.Error.newBuilder()
+                .setCode(code)
+                .setDetail(req)
+                .build();
+    }
+
+    private static final KvsServiceCode ERR_CODE = KvsServiceCode.INVALID_ARGUMENT;
+    private static final String ERR_DETAIL = "error occured";
+
+    private static KvsResponse.Error newError() {
+        return newError(ERR_CODE.getCodeNumber(), ERR_DETAIL);
+    }
+
+    private static void checkException(KvsServiceException e) {
+        assertEquals(ERR_CODE, e.getDiagnosticCode());
+        assertTrue(e.getMessage().contains(ERR_CODE.getStructuredCode()));
+        assertTrue(e.getMessage().contains(ERR_DETAIL));
+    }
+
+    private static KvsResponse.Response newBegin(long systemId) {
+        return KvsResponse.Response.newBuilder().setBegin(
+                KvsResponse.Begin.newBuilder()
+                    .setSuccess(KvsResponse.Begin.Success.newBuilder()
+                        .setTransactionHandle(
+                                Handle.newBuilder().setSystemId(systemId).build())
+                        .build())
+                    .build())
+                .build();
+    }
+
+    private static KvsResponse.Response newRollback() {
+        return KvsResponse.Response.newBuilder().setRollback(
+                KvsResponse.Rollback.newBuilder()
+                .setSuccess(newVoid()).build()).build();
+    }
+
+    private static KvsResponse.Response newDispose() {
+        return KvsResponse.Response.newBuilder().setDisposeTransaction(
+                KvsResponse.DisposeTransaction.newBuilder()
+                .setSuccess(newVoid()).build()).build();
+    }
+
+    private static RequestHandler newAcceptBegin(long systemId) throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.BEGIN,
+                RequestHandler.returns(newBegin(systemId)));
+    }
+
+    private static RequestHandler newAcceptRollback() throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.ROLLBACK,
+                RequestHandler.returns(newRollback()));
+    }
+
+    private static RequestHandler newAcceptDispose() throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
+                RequestHandler.returns(newDispose()));
+    }
+
+    @Test
+    void send_Begin_Success() throws Exception {
+        wire.next(newAcceptBegin(1234L));
+        wire.next(newAcceptRollback());
+        wire.next(newAcceptDispose());
+
+        var req = KvsRequest.Begin.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+            // NOTE: Rollback and DisposeTransaction are automatically called
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Begin_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setBegin(
+                        KvsResponse.Begin.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.Begin.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Commit_Success() throws Exception {
+        var res = KvsResponse.Response.newBuilder().setCommit(
+                    KvsResponse.Commit.newBuilder()
+                        .setSuccess(newVoid())
+                        .build())
+                    .build();
+        wire.next(accepts(KvsRequest.Request.CommandCase.COMMIT,
+                RequestHandler.returns(res)));
+
+        var req = KvsRequest.Commit.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Commit_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setCommit(
+                        KvsResponse.Commit.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.Commit.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Rollback_Success() throws Exception {
+        var res = KvsResponse.Response.newBuilder().setRollback(
+                    KvsResponse.Rollback.newBuilder()
+                        .setSuccess(newVoid())
+                        .build())
+                    .build();
+        wire.next(accepts(KvsRequest.Request.CommandCase.ROLLBACK,
+                RequestHandler.returns(res)));
+
+        var req = KvsRequest.Rollback.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Rollback_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setRollback(
+                        KvsResponse.Rollback.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.Rollback.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Put_Success() throws Exception {
+        var res = KvsResponse.Response.newBuilder().setPut(
+                    KvsResponse.Put.newBuilder()
+                        .setSuccess(
+                                KvsResponse.Put.Success.newBuilder().build())
+                        .build())
+                    .build();
+        wire.next(accepts(KvsRequest.Request.CommandCase.PUT,
+                RequestHandler.returns(res)));
+
+        var req = KvsRequest.Put.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Put_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setPut(
+                        KvsResponse.Put.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.Put.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Get_Success() throws Exception {
+        var res = KvsResponse.Response.newBuilder().setGet(
+                    KvsResponse.Get.newBuilder()
+                        .setSuccess(
+                                KvsResponse.Get.Success.newBuilder().build())
+                        .build())
+                    .build();
+        wire.next(accepts(KvsRequest.Request.CommandCase.GET,
+                RequestHandler.returns(res)));
+
+        var req = KvsRequest.Get.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_Get_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setGet(
+                        KvsResponse.Get.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.Get.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_DisposeTransaction_Success() throws Exception {
+        var res = KvsResponse.Response.newBuilder().setDisposeTransaction(
+                    KvsResponse.DisposeTransaction.newBuilder()
+                        .setSuccess(newVoid())
+                        .build())
+                    .build();
+        wire.next(accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
+                RequestHandler.returns(res)));
+
+        var req = KvsRequest.DisposeTransaction.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            delegate.send(req).await();
+        }
+        assertFalse(wire.hasRemaining());
+    }
+
+    @Test
+    void send_DisposeTransaction_Error() throws Exception {
+        wire.next(RequestHandler.returns(
+                KvsResponse.Response.newBuilder().setDisposeTransaction(
+                        KvsResponse.DisposeTransaction.newBuilder()
+                            .setError(newError())
+                            ).build()));
+
+        var req = KvsRequest.DisposeTransaction.newBuilder().build();
+        try (var delegate = new KvsServiceStub(session)) {
+            var e = assertThrows(KvsServiceException.class, () -> delegate.send(req).await());
+            checkException(e);
+        }
+        assertFalse(wire.hasRemaining());
+    }
+}

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/StubUtils.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/StubUtils.java
@@ -1,0 +1,107 @@
+package com.tsurugidb.tsubakuro.kvs.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import com.tsurugidb.kvs.proto.KvsRequest;
+import com.tsurugidb.kvs.proto.KvsResponse;
+import com.tsurugidb.kvs.proto.KvsRequest.Request;
+import com.tsurugidb.kvs.proto.KvsTransaction.Handle;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.kvs.KvsServiceCode;
+import com.tsurugidb.tsubakuro.kvs.KvsServiceException;
+import com.tsurugidb.tsubakuro.mock.RequestHandler;
+import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
+
+class StubUtils {
+
+    static RequestHandler accepts(KvsRequest.Request.CommandCase command, RequestHandler next) {
+        return new RequestHandler() {
+            @Override
+            public Response handle(int serviceId, ByteBuffer request) throws IOException, ServerException {
+                Request req = KvsRequest.Request.parseDelimitedFrom(new ByteBufferInputStream(request));
+                assertEquals(command, req.getCommandCase());
+                return next.handle(serviceId, request);
+            }
+        };
+    }
+
+    static KvsResponse.Void newVoid() {
+        return KvsResponse.Void.newBuilder()
+                .build();
+    }
+
+    static KvsResponse.Error newError(int code, String req) {
+        return KvsResponse.Error.newBuilder()
+                .setCode(code)
+                .setDetail(req)
+                .build();
+    }
+
+    static final KvsServiceCode ERR_CODE = KvsServiceCode.INVALID_ARGUMENT;
+    static final String ERR_DETAIL = "error occured";
+
+    static KvsResponse.Error newError() {
+        return newError(ERR_CODE.getCodeNumber(), ERR_DETAIL);
+    }
+
+    static void checkException(KvsServiceException e) {
+        assertEquals(ERR_CODE, e.getDiagnosticCode());
+        assertTrue(e.getMessage().contains(ERR_CODE.getStructuredCode()));
+        assertTrue(e.getMessage().contains(ERR_DETAIL));
+    }
+
+    static KvsResponse.Response newBegin(long systemId) {
+        return KvsResponse.Response.newBuilder().setBegin(
+                KvsResponse.Begin.newBuilder()
+                    .setSuccess(KvsResponse.Begin.Success.newBuilder()
+                        .setTransactionHandle(
+                                Handle.newBuilder().setSystemId(systemId).build())
+                        .build())
+                    .build())
+                .build();
+    }
+
+    static KvsResponse.Response newCommit() {
+        return KvsResponse.Response.newBuilder().setCommit(
+                KvsResponse.Commit.newBuilder()
+                .setSuccess(newVoid()).build()).build();
+    }
+
+    static KvsResponse.Response newRollback() {
+        return KvsResponse.Response.newBuilder().setRollback(
+                KvsResponse.Rollback.newBuilder()
+                .setSuccess(newVoid()).build()).build();
+    }
+
+    static KvsResponse.Response newDispose() {
+        return KvsResponse.Response.newBuilder().setDisposeTransaction(
+                KvsResponse.DisposeTransaction.newBuilder()
+                .setSuccess(newVoid()).build()).build();
+    }
+
+    static RequestHandler newAcceptBegin(long systemId) throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.BEGIN,
+                RequestHandler.returns(newBegin(systemId)));
+    }
+
+    static RequestHandler newAcceptCommit() throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.COMMIT,
+                RequestHandler.returns(newCommit()));
+    }
+
+    static RequestHandler newAcceptRollback() throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.ROLLBACK,
+                RequestHandler.returns(newRollback()));
+    }
+
+    static RequestHandler newAcceptDispose() throws IOException {
+        return accepts(KvsRequest.Request.CommandCase.DISPOSE_TRANSACTION,
+                RequestHandler.returns(newDispose()));
+    }
+
+}

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandlImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandlImplTest.java
@@ -1,0 +1,128 @@
+package com.tsurugidb.tsubakuro.kvs.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.kvs.proto.KvsRequest;
+import com.tsurugidb.tsubakuro.common.Session;
+import com.tsurugidb.tsubakuro.common.impl.SessionImpl;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.mock.MockWire;
+import com.tsurugidb.tsubakuro.util.ServerResourceHolder;
+
+class TransactionHandlImplTest {
+
+    @Test
+    void basic() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            assertEquals(systemId, tx.getSystemId());
+            assertNotEquals(null,  tx.getHandle());
+        }
+    }
+
+    @Test
+    void setAutoDispose() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            assertEquals(false, tx.setCommitAutoDisposed());
+            assertEquals(true, tx.setCommitAutoDisposed());
+        }
+    }
+
+    @Test
+    void commitCalled() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            assertEquals(false, tx.setCommitCalled());
+            assertEquals(true, tx.setCommitCalled());
+            assertEquals(true, tx.clearCommitCalled());
+            assertEquals(false, tx.clearCommitCalled());
+        }
+    }
+
+    @Test
+    void rollbackCalled() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            assertEquals(false, tx.setRollbackCalled());
+            assertEquals(true, tx.setRollbackCalled());
+            assertEquals(true, tx.clearCommitCalled());
+            assertEquals(false, tx.clearCommitCalled());
+        }
+    }
+
+    @Test
+    void singleClose() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            tx.close();
+        }
+    }
+
+    @Test
+    void doubleClose() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, null)) {
+            tx.close();
+            tx.close();
+        }
+    }
+
+    @Test
+    void holderClose() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, new ServerResourceHolder())) {
+            assertEquals(systemId, tx.getSystemId());
+        }
+    }
+
+    @Test
+    void holderSingleClose() throws Exception {
+        final long systemId = 1234L;
+        try (var tx = new TransactionHandleImpl(systemId, null, new ServerResourceHolder())) {
+            tx.close();
+        }
+    }
+
+    private final MockWire wire = new MockWire();
+    private final Session session = new SessionImpl(wire);
+
+    @AfterEach
+    void tearDown() throws IOException, InterruptedException, ServerException {
+        session.close();
+    }
+
+    @Test
+    void commitAutoClose() throws Exception {
+        wire.next(StubUtils.newAcceptCommit());
+        wire.next(StubUtils.newAcceptDispose());
+
+        final long systemId = 1234L;
+        try (var service = new KvsServiceStub(session)) {
+            try (var tx = new TransactionHandleImpl(systemId, service, new ServerResourceHolder())) {
+                service.send(KvsRequest.Commit.newBuilder().setTransactionHandle(tx.getHandle()).build()).await();
+                tx.setCommitCalled();
+            }
+        }
+    }
+
+    @Test
+    void rollbackAutoClose() throws Exception {
+        wire.next(StubUtils.newAcceptRollback());
+        wire.next(StubUtils.newAcceptDispose());
+
+        final long systemId = 1234L;
+        try (var service = new KvsServiceStub(session)) {
+            try (var tx = new TransactionHandleImpl(systemId, service, new ServerResourceHolder())) {
+                assertEquals(systemId, tx.getSystemId());
+            }
+        }
+    }
+
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/ErroneousWire.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/ErroneousWire.java
@@ -1,0 +1,51 @@
+package com.tsurugidb.tsubakuro.mock;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import com.tsurugidb.tsubakuro.channel.common.connection.Credential;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Wire;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.WireFactory;
+import com.tsurugidb.tsubakuro.exception.CoreServiceCode;
+import com.tsurugidb.tsubakuro.exception.CoreServiceException;
+import com.tsurugidb.tsubakuro.util.FutureResponse;
+import com.tsurugidb.tsubakuro.util.Owner;
+
+/**
+ * Mock {@link Wire} which always raises {@link CoreServiceException}.
+ */
+public class ErroneousWire implements Wire {
+
+    /**
+     * The scheme name of this wire.
+     */
+    public static final String SCHEME = "erroneous"; //$NON-NLS-1$
+
+    @Override
+    public FutureResponse<Response> send(int serviceId, ByteBuffer payload) {
+        return FutureResponse.raises(new CoreServiceException(CoreServiceCode.UNSUPPORTED_OPERATION));
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+
+    /**
+     * Provides {@link ErroneousWire}.
+     */
+    public static class Factory implements WireFactory {
+
+        @Override
+        public boolean accepts(URI endpoint) {
+            return Objects.equals(endpoint.getScheme(), SCHEME);
+        }
+
+        @Override
+        public FutureResponse<ErroneousWire> create(URI endpoint, Credential credential) {
+            return FutureResponse.wrap(Owner.of(new ErroneousWire()));
+        }
+    }
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockError.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockError.java
@@ -1,0 +1,26 @@
+package com.tsurugidb.tsubakuro.mock;
+
+/**
+ * An error during mock operations.
+ */
+public class MockError extends Error {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance.
+     * @param message the error message
+     */
+    public MockError(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the error message
+     * @param cause the original cause
+     */
+    public MockError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
@@ -1,0 +1,79 @@
+package com.tsurugidb.tsubakuro.mock;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.Nonnull;
+
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Wire;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.util.FutureResponse;
+import com.tsurugidb.tsubakuro.util.Owner;
+
+/**
+ * Mock implementation of {@link Wire}.
+ */
+public class MockWire implements Wire {
+
+    private final Queue<RequestHandler> handlers = new ConcurrentLinkedQueue<>();
+
+    private final AtomicReference<RequestHandler> defaultHandler = new AtomicReference<>(new RequestHandler() {
+        @Override
+        public Response handle(int serviceId, ByteBuffer payload) {
+            throw new MockError("no more handlers"); //$NON-NLS-1$
+        }
+    });
+
+    @Override
+    public FutureResponse<Response> send(int serviceId, ByteBuffer payload) throws IOException {
+        var next = handlers.poll();
+        if (next == null) {
+            next = defaultHandler.get();
+        }
+        try {
+            return FutureResponse.wrap(Owner.of(next.handle(serviceId, payload)));
+        } catch (ServerException e) {
+            return FutureResponse.raises(e);
+        }
+    }
+
+    /**
+     * Add a {@link RequestHandler} to the handler queue.
+     * @param handler the request handler
+     * @return this
+     */
+    public MockWire next(@Nonnull RequestHandler handler) {
+        Objects.requireNonNull(handler);
+        handlers.add(handler);
+        return this;
+    }
+
+    /**
+     * Add a {@link RequestHandler} that activates when there is no more handlers.
+     * @param handler the request handler
+     * @return this
+     */
+    public MockWire otherwise(@Nonnull RequestHandler handler) {
+        Objects.requireNonNull(handler);
+        handlers.add(handler);
+        return this;
+    }
+
+    /**
+     * Returns whether or not this object has more remaining handlers.
+     * @return {@code true} if this has more remaining handlers, otherwise {@code false}
+     */
+    public boolean hasRemaining() {
+        return !handlers.isEmpty();
+    }
+
+    @Override
+    public void close() throws IOException, InterruptedException {
+        handlers.clear();
+    }
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
@@ -72,6 +72,14 @@ public class MockWire implements Wire {
         return !handlers.isEmpty();
     }
 
+    /**
+     * Retrieves the number of remaining handlers
+     * @return number of remaining handlers
+     */
+    public int size() {
+        return handlers.size();
+    }
+
     @Override
     public void close() throws IOException, InterruptedException {
         handlers.clear();

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/RequestHandler.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/RequestHandler.java
@@ -1,0 +1,99 @@
+package com.tsurugidb.tsubakuro.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import com.google.protobuf.Message;
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+
+/**
+ * Handles request for wires and returns its response.
+ */
+@FunctionalInterface
+public interface RequestHandler {
+
+    /**
+     * Handles a request message and returns a response for it.
+     * @param serviceId the destination service ID
+     * @param request the request payload
+     * @return the response
+     * @throws IOException if I/O error while handling the request
+     * @throws ServerException if server error while handling the request
+     */
+    Response handle(int serviceId, ByteBuffer request) throws IOException, ServerException;
+
+    /**
+     * Creates a new request handler which returns the given response payload.
+     * @param response the response payload
+     * @param channels the sub-responses
+     * @return the request handler
+     */
+    static RequestHandler returns(@Nonnull ByteBuffer response, @Nonnull Map<String, ByteBuffer> channels) {
+        Objects.requireNonNull(response);
+        Objects.requireNonNull(channels);
+        return (id, request) -> new SimpleResponse(response, channels);
+    }
+
+    /**
+     * Creates a new request handler which returns the given response payload.
+     * @param response the response payload
+     * @param channels the sub-responses
+     * @return the request handler
+     */
+    @SafeVarargs
+    static RequestHandler returns(@Nonnull ByteBuffer response, @Nonnull Map.Entry<String, ByteBuffer>... channels) {
+        Objects.requireNonNull(response);
+        Objects.requireNonNull(channels);
+        return returns(response, Map.ofEntries(channels));
+    }
+
+    /**
+     * Creates a new request handler which returns the given response payload.
+     * @param response the response payload
+     * @param channels the sub-responses
+     * @return the request handler
+     */
+    @SafeVarargs
+    static RequestHandler returns(@Nonnull byte[] response, @Nonnull Map.Entry<String, byte[]>... channels) {
+        Objects.requireNonNull(response);
+        Objects.requireNonNull(channels);
+        return returns(ByteBuffer.wrap(response), Arrays.stream(channels)
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> ByteBuffer.wrap(it.getValue()))));
+    }
+
+    /**
+     * Creates a new request handler which returns the given response payload.
+     * @param response the response payload
+     * @return the request handler
+     * @throws IOException if I/O error while handling the request
+     */
+    static RequestHandler returns(@Nonnull Message response) throws IOException {
+        Objects.requireNonNull(response);
+        // NOTE: only calling "response.toByteArray()" causes
+        // com.google.protobuf.InvalidProtocolBufferException
+        try (var buffer = new ByteArrayOutputStream()) {
+            response.writeDelimitedTo(buffer);
+            return returns(buffer.toByteArray());
+        }
+    }
+
+    /**
+     * Creates a new request handler which throws the given exception.
+     * @param exception the exception object
+     * @return the request handler
+     */
+    static RequestHandler raises(@Nonnull ServerException exception) {
+        Objects.requireNonNull(exception);
+        return (id, request) -> {
+            throw exception;
+        };
+    }
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/SimpleResponse.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/SimpleResponse.java
@@ -1,0 +1,112 @@
+package com.tsurugidb.tsubakuro.mock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nonnull;
+
+import com.tsurugidb.tsubakuro.channel.common.connection.wire.Response;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.util.ByteBufferInputStream;
+
+/**
+ * A simple implementation of {@link Response} which just returns payload data.
+ */
+public class SimpleResponse implements Response {
+
+    private final ByteBuffer main;
+
+    private final Map<String, ByteBuffer> subs;
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    /**
+     * Creates a new instance.
+     * @param main the main response data
+     * @param subMap map of sub response ID and its data
+     */
+    public SimpleResponse(@Nonnull ByteBuffer main, @Nonnull Map<String, ByteBuffer> subMap) {
+        Objects.requireNonNull(main);
+        Objects.requireNonNull(subMap);
+        this.main = main;
+        this.subs = new TreeMap<>();
+        for (var entry : subMap.entrySet()) {
+            this.subs.put(entry.getKey(), entry.getValue().duplicate());
+        }
+    }
+
+    /**
+     * Creates a new instance, without any attached data.
+     * @param main the main response data
+     */
+    public SimpleResponse(@Nonnull ByteBuffer main) {
+        this(main, Collections.emptyMap());
+    }
+
+    @Override
+    public boolean isMainResponseReady() {
+        return true;
+    }
+
+    @Override
+    public ByteBuffer waitForMainResponse() {
+        return main;
+    }
+
+    @Override
+    public ByteBuffer waitForMainResponse(long timeout, TimeUnit unit) {
+        return main;
+    }
+
+    /**
+     * Returns the sub-response identifiers included in this response.
+     * @return the sub-response identifiers
+     * @throws IOException if I/O error was occurred while opening the sub-responses
+     * @throws ServerException if server error was occurred while opening the sub-responses
+     * @throws InterruptedException if interrupted by other threads while opening the sub-responses
+     */
+    public Collection<String> getSubResponseIds() throws IOException, ServerException, InterruptedException {
+        return new ArrayList<>(subs.keySet());
+    }
+
+    @Override
+    public InputStream openSubResponse(String id) throws IOException, ServerException, InterruptedException {
+        checkOpen();
+        var data = subs.remove(id);
+        if (data == null) {
+            throw new NoSuchElementException(id);
+        }
+        return new ByteBufferInputStream(data);
+    }
+
+    private void checkOpen() {
+        if (closed.get()) {
+            throw new IllegalStateException("response was already closed");
+        }
+    }
+
+    @Override
+    public void close() throws IOException, InterruptedException {
+        subs.clear();
+        closed.set(true);
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format(
+                "SimpleResponse(main={0}, sub={1})",
+                main.remaining(),
+                subs.keySet());
+    }
+}

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/package-info.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides mock classes.
+ */
+package com.tsurugidb.tsubakuro.mock;


### PR DESCRIPTION
・sandbox-tsubakuro-coreにある、MockWireやそれに関係するクラスを tsubakuro/modules/session/src/testFixtures 配下に移植しました。
・tsubakuro/modules/{debug, kvs}のテストに、MockWireを利用したテストを移植・追加しました。特に、commit/rollbackが呼ばれていなければ自動的にrollbackすること、commitはAutoDipose=trueで要求するのでトランザクションハンドルの後始末で disposeTransaction要求が飛ばないこと（それ以外は飛ぶ）などを単体テストで確認できるようになりました。