### PR TITLE
always dispose resultSetImpl from ServerResourceHolder at resultSetIm…

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetImpl.java
@@ -417,11 +417,12 @@ public class ResultSetImpl implements ResultSet {
                 }
             } catch (TimeoutException e) {
                 throw new ResponseTimeoutException(e);
-            }
-            if (closeHandler != null) {
-                Lang.suppress(
-                        e -> LOG.warn("error occurred while collecting garbage", e),
-                        () -> closeHandler.onClosed(this));
+            } finally {
+                if (closeHandler != null) {
+                    Lang.suppress(
+                            e -> LOG.warn("error occurred while collecting garbage", e),
+                            () -> closeHandler.onClosed(this));
+                }
             }
         }
     }


### PR DESCRIPTION
…pl.close()
https://github.com/project-tsurugi/tsurugi-issues/issues/554