### PR TITLE
docs: add feature to collect docs of diagnostic code.

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
@@ -6,100 +6,120 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tsurugidb.diagnostics.proto.Diagnostics;
+import com.tsurugidb.tsubakuro.util.Doc;
 
 /**
  * Code of server core diagnostics.
  */
+@Doc("diagnostics of the service infrastructure.")
 public enum CoreServiceCode implements DiagnosticCode {
 
     /**
      * Unknown error.
      */
+    @Doc("unknown error was occurred in the server.")
     UNKNOWN(0, Diagnostics.Code.UNKNOWN),
 
     /**
      * Unrecognized code.
      */
+    @Doc("the server received an unrecognized message.")
     UNRECOGNIZED(1, Diagnostics.Code.UNRECOGNIZED),
 
     /**
      * system is something wrong.
      */
+    @Doc("the server system is something wrong.")
     SYSTEM_ERROR(1_00, Diagnostics.Code.SYSTEM_ERROR),
 
     /**
      * operation is not supported.
      */
+    @Doc("the requested operation is not supported.")
     UNSUPPORTED_OPERATION(1_01, Diagnostics.Code.UNSUPPORTED_OPERATION),
 
     /**
      * operation was requested in illegal or inappropriate time.
      */
+    @Doc("operation was requested in illegal or inappropriate time.")
     ILLEGAL_STATE(1_02, Diagnostics.Code.ILLEGAL_STATE),
 
     /**
      * I/O error was occurred.
      */
+    @Doc("I/O error was occurred in the server.")
     IO_ERROR(1_03, Diagnostics.Code.IO_ERROR),
 
     /**
      * out of memory.
      */
+    @Doc("the server is out of memory.")
     OUT_OF_MEMORY(1_04, Diagnostics.Code.OUT_OF_MEMORY),
 
     /**
      * reached server resource limit.
      */
+    @Doc("the server reached resource limit.")
     RESOURCE_LIMIT_REACHED(1_05, Diagnostics.Code.RESOURCE_LIMIT_REACHED),
 
     /**
      * authentication was failed.
      */
+    @Doc("authentication was failed.")
     AUTHENTICATION_ERROR(2_01, Diagnostics.Code.AUTHENTICATION_ERROR),
 
     /**
      * request is not permitted.
      */
+    @Doc("request is not permitted.")
     PERMISSION_ERROR(2_02, Diagnostics.Code.PERMISSION_ERROR),
 
     /**
      * access right has been expired.
      */
+    @Doc("access right has been expired.")
     ACCESS_EXPIRED(2_03, Diagnostics.Code.ACCESS_EXPIRED),
 
     /**
      * refresh right has been expired.
      */
+    @Doc("refresh right has been expired.")
     REFRESH_EXPIRED(2_04, Diagnostics.Code.REFRESH_EXPIRED),
 
     /**
      * credential information is broken.
      */
+    @Doc("credential information is broken.")
     BROKEN_CREDENTIAL(2_05, Diagnostics.Code.BROKEN_CREDENTIAL),
 
     /**
      * the current session is already closed.
      */
+    @Doc("the current session is already closed.")
     SESSION_CLOSED(3_01, Diagnostics.Code.SESSION_CLOSED),
 
     /**
      * the current session is expired.
      */
+    @Doc("the current session is expired.")
     SESSION_EXPIRED(3_02, Diagnostics.Code.SESSION_EXPIRED),
 
     /**
      * the destination service was not found.
      */
+    @Doc("the destination service was not found.")
     SERVICE_NOT_FOUND(4_01, Diagnostics.Code.SERVICE_NOT_FOUND),
 
     /**
      * the destination service was not found.
      */
+    @Doc("the destination service was not found.")
     SERVICE_UNAVAILABLE(4_02, Diagnostics.Code.SERVICE_UNAVAILABLE),
 
     /**
      * request payload is not valid.
      */
+    @Doc("the service received a request message with invalid payload.")
     INVALID_REQUEST(5_01, Diagnostics.Code.INVALID_REQUEST),
 
     ;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
@@ -1,0 +1,80 @@
+package com.tsurugidb.tsubakuro.exception;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import com.tsurugidb.tsubakuro.util.ClassCollector;
+import com.tsurugidb.tsubakuro.util.DocumentedElement;
+
+/**
+ * Collects declared {@link DiagnosticCode} from diagnostic code class definition files in class-path.
+ *
+ * <p>
+ * Locate the diagnostic code class definition file as {@link #PATH_METADATA "META-INF/tsurugidb/diagnostic-code"},
+ * and list the target class name on each line in the file (UTF-8).
+ * </p>
+ * @see DiagnosticCode
+ */
+public final class DiagnosticCodeCollector {
+
+    /**
+     * Path to the diagnostic code class definition file in class-path.
+     */
+    public static final String PATH_METADATA = "META-INF/tsurugidb/diagnostic-code"; //$NON-NLS-1$
+
+    /**
+     * Character set encoding of {@link #PATH_METADATA}.
+     */
+    public static final Charset ENCODING_METADATA = ClassCollector.ENCODING_METADATA;
+
+    /**
+     * Returns a list of registered {@link DiagnosticCode} implementations.
+     * @param failOnError {@code true} to raise and error if any exceptions are occurred,
+     *      or {@code false} to ignore such the entries and only record logs
+     * @return available {@link DiagnosticCode} implementations
+     * @throws IOException if failed to load server client definition files
+     * @throws IOException if the definitions are not valid when {@code failOnError} is {@code true}
+     */
+    public static List<Class<? extends DiagnosticCode>> collect(boolean failOnError) throws IOException {
+        return collect(DiagnosticCode.class.getClassLoader(), failOnError);
+    }
+
+    /**
+     * Returns a list of registered {@link DiagnosticCode} implementations.
+     * @param loader the class loader to load the subclasses
+     * @param failOnError {@code true} to raise and error if any exceptions are occurred,
+     *      or {@code false} to ignore such the entries and only record logs
+     * @return available {@link DiagnosticCode} implementations
+     * @throws IOException if failed to load server client definition files
+     * @throws IOException if the definitions are not valid when {@code failOnError} is {@code true}
+     */
+    public static List<Class<? extends DiagnosticCode>> collect(
+            @Nonnull ClassLoader loader,
+            boolean failOnError) throws IOException {
+        Objects.requireNonNull(loader);
+        return ClassCollector.collect(DiagnosticCode.class, loader, PATH_METADATA, failOnError);
+    }
+
+    /**
+     * Extracts documents about individual diagnostics from the specified {@link DiagnosticCode} class.
+     * @param codeClass the target {@link DiagnosticCode} class
+     * @return the service message version code, or {@code empty} if it is not defined
+     */
+    public static <T> List<DocumentedElement<T>> findDocument(@Nonnull Class<T> codeClass) {
+        Objects.requireNonNull(codeClass);
+        if (!Enum.class.isAssignableFrom(codeClass)) {
+            return List.of();
+        }
+        @SuppressWarnings("unchecked")
+        List<DocumentedElement<T>> elements = DocumentedElement.constantsOf(codeClass.asSubclass(Enum.class));
+        return elements;
+    }
+
+    private DiagnosticCodeCollector() {
+        throw new AssertionError();
+    }
+}

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
@@ -66,12 +66,7 @@ public final class DiagnosticCodeCollector {
      */
     public static <T> List<DocumentedElement<T>> findDocument(@Nonnull Class<T> codeClass) {
         Objects.requireNonNull(codeClass);
-        if (!Enum.class.isAssignableFrom(codeClass)) {
-            return List.of();
-        }
-        @SuppressWarnings("unchecked")
-        List<DocumentedElement<T>> elements = DocumentedElement.constantsOf(codeClass.asSubclass(Enum.class));
-        return elements;
+        return DocumentedElement.constantsOf(codeClass);
     }
 
     private DiagnosticCodeCollector() {

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
@@ -1,0 +1,179 @@
+package com.tsurugidb.tsubakuro.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A basic implementation of {@link DocumentSnippet}.
+ */
+public class BasicDocumentSnippet implements DocumentSnippet {
+
+    private final List<String> description;
+
+    private final List<String> notes;
+
+    private final List<Reference> references;
+
+    /**
+     * Creates an empty instance.
+     */
+    public BasicDocumentSnippet() {
+        this(List.of(), List.of(), List.of());
+    }
+
+    /**
+     * Creates a new instance.
+     * @param description the description in the document snippet
+     * @param notes additional notesin the document snippet
+     * @param references optional references in the document snippet
+     */
+    public BasicDocumentSnippet(
+            @Nonnull List<? extends String> description,
+            @Nonnull List<? extends String> notes,
+            @Nonnull List<? extends Reference> references) {
+        Objects.requireNonNull(description);
+        Objects.requireNonNull(notes);
+        Objects.requireNonNull(references);
+        this.description = List.copyOf(description);
+        this.notes = List.copyOf(notes);
+        this.references = List.copyOf(references);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param description the description in the document snippet
+     * @return the created instance
+     */
+    public static BasicDocumentSnippet of(@Nonnull String... description) {
+        Objects.requireNonNull(description);
+        return new BasicDocumentSnippet(Arrays.asList(description), List.of(), List.of());
+    }
+
+    /**
+     * Creates a new instance from the {@code Doc} annotation.
+     * @param annotation the source annotation
+     * @return the corresponding value
+     */
+    public static BasicDocumentSnippet of(@Nonnull Doc annotation) {
+        var description = Arrays.asList(annotation.value());
+        var notes = Arrays.asList(annotation.note());
+        var references = Arrays.stream(annotation.reference())
+                .filter(it -> !it.isBlank())
+                .map(it -> {
+                    var delimAt = it.lastIndexOf(Doc.REFERENCE_DELIMITER);
+                    if (delimAt < 0) {
+                        return new BasicReference(it, null);
+                    }
+                    var title = it.substring(0, delimAt).strip();
+                    var location = it.substring(delimAt + 1).strip();
+                    return new BasicReference(location, title);
+                })
+                .collect(Collectors.toList());
+        return new BasicDocumentSnippet(description, notes, references);
+    }
+
+    @Override
+    public List<String> getDescription() {
+        return description;
+    }
+
+    @Override
+    public List<String> getNotes() {
+        return notes;
+    }
+
+    @Override
+    public List<Reference> getReferences() {
+        return references;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, notes, references);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        BasicDocumentSnippet other = (BasicDocumentSnippet) obj;
+        return Objects.equals(description, other.description)
+                && Objects.equals(notes, other.notes)
+                && Objects.equals(references, other.references);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("BasicDocumentSnippet(description=%s, notes=%s, references=%s)", //$NON-NLS-1$
+                description, notes, references);
+    }
+
+    /**
+     * A basic implementation of {@link com.tsurugidb.tsubakuro.util.DocumentSnippet.Reference Reference}.
+     */
+    public static class BasicReference implements Reference {
+
+        private final String title;
+
+        private final String location;
+
+        /**
+         * Creates a new instance.
+         * @param location the location of the reference
+         * @param title the title of the reference (optional)
+         */
+        public BasicReference(@Nonnull String location, @Nullable String title) {
+            Objects.requireNonNull(location);
+            this.title = title;
+            this.location = location;
+        }
+
+        @Override
+        public Optional<String> getTitle() {
+            return Optional.ofNullable(title);
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(location, title);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            var other = (BasicReference) obj;
+            return Objects.equals(location, other.location) && Objects.equals(title, other.title);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Reference(location=%s, title=%s)", location, title); //$NON-NLS-1$
+        }
+    }
+}

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ClassCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ClassCollector.java
@@ -1,0 +1,128 @@
+package com.tsurugidb.tsubakuro.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Collects declared classes from its definition files in class-path.
+ */
+public final class ClassCollector {
+
+    static final Logger LOG = LoggerFactory.getLogger(ClassCollector.class);
+
+    /**
+     * Character set encoding of definition files.
+     */
+    public static final Charset ENCODING_METADATA = StandardCharsets.UTF_8;
+
+    private static final char COMMENT_START = '#';
+
+    /**
+     * Returns a list of available subclasses of the specified class, listed in the definition file.
+     * @param <T>  the service class type
+     * @param serviceClass the service class
+     * @param loader the class loader to load the subclasses
+     * @param definitionFilePath path to the definition file in the classpath
+     * @param failOnError {@code true} to raise and error if any exceptions are occurred,
+     *      or {@code false} to ignore such the entries and only record logs
+     * @return available subclasses
+     * @throws IOException if failed to load the definition files
+     * @throws IOException if the definitions are not valid when {@code failOnError} is {@code true}
+     */
+    public static <T> List<Class<? extends T>> collect(
+            @Nonnull Class<T> serviceClass,
+            @Nonnull ClassLoader loader,
+            @Nonnull String definitionFilePath,
+            boolean failOnError) throws IOException {
+        Objects.requireNonNull(loader);
+        var results = new ArrayList<Class<? extends T>>();
+        LOG.debug("loading {}", definitionFilePath); //$NON-NLS-1$
+        var resources = loader.getResources(definitionFilePath);
+        while (resources.hasMoreElements()) {
+            var element = resources.nextElement();
+            LOG.debug("found definition file of {}: {}", serviceClass.getName(), element); //$NON-NLS-1$
+
+            var found = collectFromUrl(element, serviceClass, loader, failOnError);
+            results.addAll(found);
+        }
+        return results;
+    }
+
+    private static <T> List<Class<? extends T>> collectFromUrl(
+            URL url,
+            Class<T> serviceClass, ClassLoader loader,
+            boolean failOnError) throws IOException {
+        var results = new ArrayList<Class<? extends T>>();
+        try (var in = url.openStream();
+                var isr = new InputStreamReader(in, ENCODING_METADATA);
+                var reader = new BufferedReader(isr)) {
+            while (true) {
+                var line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+                // strip comments
+                var commentAt = line.indexOf(COMMENT_START);
+                if (commentAt >= 0) {
+                    line = line.substring(0, commentAt);
+                }
+                var className = line.trim();
+                // skip empty lines
+                if (className.isEmpty()) {
+                    continue;
+                }
+
+                LOG.debug("loading class: {}", className); //$NON-NLS-1$
+                try {
+                    var clazz = loader.loadClass(className);
+                    results.add(clazz.asSubclass(serviceClass));
+                } catch (ClassNotFoundException e) {
+                    var message = MessageFormat.format(
+                            "cannot load a class: {0} ({1})",
+                            className,
+                            url);
+                    if (failOnError) {
+                        throw new IOException(message, e);
+                    }
+                    LOG.warn(message);
+                } catch (ClassCastException e) {
+                    var message = MessageFormat.format(
+                            "not a subclass of {0}: {1} ({2})",
+                            serviceClass.getName(),
+                            className,
+                            url);
+                    if (failOnError) {
+                        throw new IOException(message, e);
+                    }
+                    LOG.warn(message);
+                }
+            }
+        } catch (IOException e) {
+            if (failOnError) {
+                throw e;
+            }
+            LOG.warn(MessageFormat.format(
+                    "error occurred while loading definition file: {0}",
+                    url));
+        }
+        return results;
+    }
+
+
+    private ClassCollector() {
+        throw new AssertionError();
+    }
+}

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
@@ -23,6 +23,11 @@ import java.lang.annotation.Target;
 public @interface Doc {
 
     /**
+     * A delimiter character to separate reference title and its location.
+     */
+    char REFERENCE_DELIMITER = '@';
+
+    /**
      * Description of the target element.
      * @return Description of the target element
      */
@@ -34,7 +39,6 @@ public @interface Doc {
      */
     String[] note() default {};
 
-
     /**
      * Optional references for the target element.
      * <p>
@@ -45,6 +49,7 @@ public @interface Doc {
      * <li> <code>page-title&#64;https://...</code> </li>
      * </ul>
      * @return optional references for the target element.
+     * @see #REFERENCE_DELIMITER
      */
     String[] reference() default {};
 }

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
@@ -1,0 +1,51 @@
+package com.tsurugidb.tsubakuro.util;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents a snippet of documentation, reflects to {@link Doc}.
+ * @see Doc
+ */
+public interface DocumentSnippet {
+
+    /**
+     * Returns the description of the element.
+     * @return the lines of descriptions.
+     */
+    List<String> getDescription();
+
+    /**
+     * Returns the additional note for the element.
+     * @return a list of note text
+     */
+    default List<String> getNotes() {
+        return List.of();
+    }
+
+    /**
+     * Returns the optional references for the target element.
+     * @return a list of references
+     */
+    default List<Reference> getReferences() {
+        return List.of();
+    }
+
+    /**
+     * Represents a reference of the {@link DocumentedElement}.
+     */
+    interface Reference {
+
+        /**
+         * Returns optional title of this reference.
+         * @return the title of the reference, or {@code empty} if it is not sure
+         */
+        Optional<String> getTitle();
+
+        /**
+         * Returns the location of this reference.
+         * @return the location string, generally a URL
+         */
+        String getLocation();
+    }
+}

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
@@ -1,0 +1,89 @@
+package com.tsurugidb.tsubakuro.util;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An element with {@link DocumentSnippet}.
+ * @param <T> the element type
+ */
+public class DocumentedElement<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DocumentedElement.class);
+
+    private final DocumentSnippet document;
+
+    private final T element;
+
+    /**
+     * Creates a new instance.
+     * @param document the document
+     * @param element the documented element
+     */
+    public DocumentedElement(@Nonnull DocumentSnippet document, @Nonnull T element) {
+        Objects.requireNonNull(document);
+        Objects.requireNonNull(element);
+        this.document = document;
+        this.element = element;
+    }
+
+    /**
+     * Creates a list of {@link DocumentedElement} about enum constants.
+     * @param <T> the enum type
+     * @param enumClass the enum class object
+     * @return a list of created instances for the constants of the specified enum type
+     */
+    public static <T extends Enum<T>> List<DocumentedElement<T>> constantsOf(@Nonnull Class<T> enumClass) {
+        Objects.requireNonNull(enumClass);
+        var fields = enumClass.getFields();
+        var results = new ArrayList<DocumentedElement<T>>(fields.length);
+        var constants = enumClass.getEnumConstants();
+        if (constants == null) {
+            return List.of(); // not an enum type
+        }
+        for (var constant : constants) {
+            Field field;
+            try {
+                field = enumClass.getField(constant.name());
+            } catch (NoSuchFieldException | SecurityException e) {
+                // may not occur
+                LOG.warn("failed to obtain enum constant declaration: {}.{}", enumClass.getName(), constant.name(), e); //$NON-NLS-1$
+                continue;
+            }
+            var document = Optional.ofNullable(field.getAnnotation(Doc.class))
+                    .map(BasicDocumentSnippet::of)
+                    .orElseGet(BasicDocumentSnippet::new);
+            results.add(new DocumentedElement<>(document, constant));
+        }
+        return results;
+    }
+
+    /**
+     * Returns the document snippet for the element.
+     * @return the document snippet
+     */
+    public DocumentSnippet getDocument() {
+        return document;
+    }
+
+    /**
+     * Returns the wrapped element.
+     * @return the wrapped element
+     */
+    public T getElement() {
+        return element;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("DocumentedElement(document=%s, element=%s)", document, element); //$NON-NLS-1$
+    }
+}

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
@@ -37,19 +37,24 @@ public class DocumentedElement<T> {
 
     /**
      * Creates a list of {@link DocumentedElement} about enum constants.
+     * <p>
+     * Note: For convenience, the type parameter bound does not have {@code Enum<T>}.
+     * </p>
      * @param <T> the enum type
      * @param enumClass the enum class object
-     * @return a list of created instances for the constants of the specified enum type
+     * @return a list of created instances for the constants of the specified enum type,
+     *      or empty list if the specified type does not indicates an enum type
      */
-    public static <T extends Enum<T>> List<DocumentedElement<T>> constantsOf(@Nonnull Class<T> enumClass) {
+    public static <T> List<DocumentedElement<T>> constantsOf(@Nonnull Class<T> enumClass) {
         Objects.requireNonNull(enumClass);
+        if (!Enum.class.isAssignableFrom(enumClass)) {
+            return List.of();
+        }
         var fields = enumClass.getFields();
         var results = new ArrayList<DocumentedElement<T>>(fields.length);
         var constants = enumClass.getEnumConstants();
-        if (constants == null) {
-            return List.of(); // not an enum type
-        }
-        for (var constant : constants) {
+        for (var c : constants) {
+            var constant = (Enum<?>) c;
             Field field;
             try {
                 field = enumClass.getField(constant.name());
@@ -61,7 +66,7 @@ public class DocumentedElement<T> {
             var document = Optional.ofNullable(field.getAnnotation(Doc.class))
                     .map(BasicDocumentSnippet::of)
                     .orElseGet(BasicDocumentSnippet::new);
-            results.add(new DocumentedElement<>(document, constant));
+            results.add(new DocumentedElement<>(document, c));
         }
         return results;
     }

--- a/modules/common/src/main/resources/META-INF/tsurugidb/diagnostic-code
+++ b/modules/common/src/main/resources/META-INF/tsurugidb/diagnostic-code
@@ -1,0 +1,1 @@
+com.tsurugidb.tsubakuro.exception.CoreServiceCode

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
@@ -1,0 +1,128 @@
+package com.tsurugidb.tsubakuro.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.tsubakuro.util.BasicDocumentSnippet;
+
+class DiagnosticCodeCollectorTest {
+
+    private Path temp;
+
+    private URLClassLoader prepare(String... lines) throws IOException {
+        assertNull(temp);
+        temp = Files.createTempDirectory("tsubakuro-");
+        var file = temp.resolve(Path.of(DiagnosticCodeCollector.PATH_METADATA));
+        Files.createDirectories(file.getParent());
+        Files.createFile(file);
+        Files.writeString(
+                file,
+                String.join("\n", lines),
+                DiagnosticCodeCollector.ENCODING_METADATA);
+        return new URLClassLoader(new URL[] { temp.toFile().toURI().toURL() });
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        if (temp != null) {
+            Files.walkFileTree(temp, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return super.postVisitDirectory(dir, exc);
+                }
+            });
+        }
+    }
+
+    @Test
+    void collect() throws Exception {
+        try (var cl = prepare(new String[] {
+                MockDiagnosticCode.class.getName(),
+        })) {
+            var results = DiagnosticCodeCollector.collect(cl, true);
+            assertTrue(results.contains(MockDiagnosticCode.class));
+        }
+    }
+
+    @Test
+    void comments() throws Exception {
+        try (var cl = prepare(new String[] {
+                "# begin",
+                "",
+                "  " + MockDiagnosticCode.class.getName() + " # testing",
+                "# end",
+        })) {
+            var results = DiagnosticCodeCollector.collect(cl, true);
+            assertTrue(results.contains(MockDiagnosticCode.class));
+        }
+    }
+
+    @Test
+    void empty() throws Exception {
+        try (var cl = prepare(new String[] {})) {
+            var results = DiagnosticCodeCollector.collect(cl, true);
+            assertFalse(results.contains(MockDiagnosticCode.class));
+        }
+    }
+
+    @Test
+    void missing() throws Exception {
+        try (var cl = prepare(new String[] {
+                MockDiagnosticCode.class.getName() + "_MISSING",
+        })) {
+            assertThrows(IOException.class, () -> DiagnosticCodeCollector.collect(cl, true));
+        }
+    }
+
+    @Test
+    void inconsistent() throws Exception {
+        try (var cl = prepare(new String[] {
+                DiagnosticCodeCollector.class.getName(),
+        })) {
+            assertThrows(IOException.class, () -> DiagnosticCodeCollector.collect(cl, true));
+        }
+    }
+
+    @Test
+    void collect_ignoreError() throws Exception {
+        try (var cl = prepare(new String[] {
+                DiagnosticCodeCollector.class.getName(),
+                MockDiagnosticCode.class.getName(),
+                MockDiagnosticCode.class.getName() + "_MISSING",
+        })) {
+            var results = DiagnosticCodeCollector.collect(cl, false);
+            assertTrue(results.contains(MockDiagnosticCode.class));
+        }
+    }
+
+    @Test
+    void findDocument() {
+        var docs = DiagnosticCodeCollector.findDocument(MockDiagnosticCode.class);
+        assertEquals(1, docs.size());
+
+        var c = docs.get(0);
+        assertEquals(MockDiagnosticCode.TESTING, c.getElement());
+        assertEquals(BasicDocumentSnippet.of("OK"), c.getDocument());
+    }
+}

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
@@ -117,6 +117,12 @@ class DiagnosticCodeCollectorTest {
     }
 
     @Test
+    void collect_system() throws Exception {
+        var results = DiagnosticCodeCollector.collect(true);
+        assertTrue(results.contains(CoreServiceCode.class));
+    }
+
+    @Test
     void findDocument() {
         var docs = DiagnosticCodeCollector.findDocument(MockDiagnosticCode.class);
         assertEquals(1, docs.size());
@@ -124,5 +130,13 @@ class DiagnosticCodeCollectorTest {
         var c = docs.get(0);
         assertEquals(MockDiagnosticCode.TESTING, c.getElement());
         assertEquals(BasicDocumentSnippet.of("OK"), c.getDocument());
+    }
+
+    @Test
+    void findDocument_system() {
+        var docs = DiagnosticCodeCollector.findDocument(CoreServiceCode.class);
+        for (var element : docs) {
+            System.out.println(element);
+        }
     }
 }

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/MockDiagnosticCode.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/MockDiagnosticCode.java
@@ -1,0 +1,27 @@
+package com.tsurugidb.tsubakuro.exception;
+
+import com.tsurugidb.tsubakuro.util.Doc;
+
+/**
+ * A test mock of {@link DiagnosticCode}.
+ */
+public enum MockDiagnosticCode implements DiagnosticCode {
+
+    /**
+     * example constant.
+     */
+    @Doc("OK")
+    TESTING,
+
+    ;
+
+    @Override
+    public String getStructuredCode() {
+        return String.format("MCK-%05d", getCodeNumber());
+    }
+
+    @Override
+    public int getCodeNumber() {
+        return 0;
+    }
+}

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
@@ -1,0 +1,118 @@
+package com.tsurugidb.tsubakuro.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class BasicDocumentSnippetTest {
+
+    private static Doc pick(String name) {
+        try {
+            var doc = BasicDocumentSnippetTest.class.getDeclaredMethod(name).getAnnotation(Doc.class);
+            assertNotNull(doc);
+            return doc;
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    void new_empty() {
+        var doc = new BasicDocumentSnippet();
+        assertEquals(new BasicDocumentSnippet(List.of(), List.of(), List.of()), doc);
+    }
+
+    @Doc("OK")
+    @Test
+    void of_simple() {
+        var a = pick("of_simple");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(BasicDocumentSnippet.of("OK"), doc);
+    }
+
+    @Doc({"a", "b", "c"})
+    @Test
+    void of_description_multiple() {
+        var a = pick("of_description_multiple");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(BasicDocumentSnippet.of("a", "b", "c"), doc);
+    }
+
+    @Doc(value = "OK", note = "NOTE")
+    @Test
+    void of_note() {
+        var a = pick("of_note");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(new BasicDocumentSnippet(List.of("OK"), List.of("NOTE"), List.of()), doc);
+    }
+
+    @Doc(value = "OK", note = {"a", "b", "c"})
+    @Test
+    void of_note_multiple() {
+        var a = pick("of_note_multiple");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(new BasicDocumentSnippet(List.of("OK"), List.of("a", "b", "c"), List.of()), doc);
+    }
+
+    @Doc(value = "OK", reference = "http://example.com")
+    @Test
+    void of_reference() {
+        var a = pick("of_reference");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of(new BasicDocumentSnippet.BasicReference("http://example.com", null))),
+                doc,
+                doc.toString());
+    }
+
+    @Doc(value = "OK", reference = " example page @ http://example.com")
+    @Test
+    void of_reference_title() {
+        var a = pick("of_reference_title");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of(new BasicDocumentSnippet.BasicReference("http://example.com", "example page"))),
+                doc,
+                doc.toString());
+    }
+
+    @Doc(value = "OK", reference = " page @ example @ http://example.com")
+    @Test
+    void of_reference_title_multiple_delimiter() {
+        var a = pick("of_reference_title_multiple_delimiter");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of(new BasicDocumentSnippet.BasicReference("http://example.com", "page @ example"))),
+                doc,
+                doc.toString());
+    }
+
+    @Doc(value = "OK", reference = {"http://example.com/1", "http://example.com/2", "http://example.com/3"})
+    @Test
+    void of_reference_multiple() {
+        var a = pick("of_reference_multiple");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of(
+                                new BasicDocumentSnippet.BasicReference("http://example.com/1", null),
+                                new BasicDocumentSnippet.BasicReference("http://example.com/2", null),
+                                new BasicDocumentSnippet.BasicReference("http://example.com/3", null))),
+                doc,
+                doc.toString());
+    }
+}

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
@@ -1,0 +1,74 @@
+package com.tsurugidb.tsubakuro.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class DocumentedElementTest {
+
+    enum Empty {
+        // no constants
+    }
+
+    @Test
+    void constantsOf_empty() {
+        var constants = DocumentedElement.constantsOf(Empty.class);
+        assertEquals(List.of(), constants);
+    }
+
+    enum Simple {
+        @Doc("OK")
+        C
+    }
+
+    @Test
+    void constantsOf_simple() {
+        var constants = DocumentedElement.constantsOf(Simple.class);
+        assertEquals(1, constants.size());
+
+        var c = constants.get(0);
+        assertEquals(Simple.C, c.getElement());
+        assertEquals(BasicDocumentSnippet.of("OK"), c.getDocument());
+    }
+
+    enum Multiple {
+        @Doc("a") A,
+        @Doc("b") B,
+        @Doc("c") C,
+    }
+
+    @Test
+    void constantsOf_multiple() {
+        var constants = DocumentedElement.constantsOf(Multiple.class);
+        assertEquals(3, constants.size());
+
+        var a = constants.get(0);
+        assertEquals(Multiple.A, a.getElement());
+        assertEquals(BasicDocumentSnippet.of("a"), a.getDocument());
+
+        var b = constants.get(1);
+        assertEquals(Multiple.B, b.getElement());
+        assertEquals(BasicDocumentSnippet.of("b"), b.getDocument());
+
+        var c = constants.get(2);
+        assertEquals(Multiple.C, c.getElement());
+        assertEquals(BasicDocumentSnippet.of("c"), c.getDocument());
+    }
+
+
+    enum NoDoc {
+        C
+    }
+
+    @Test
+    void constantsOf_nodoc() {
+        var constants = DocumentedElement.constantsOf(NoDoc.class);
+        assertEquals(1, constants.size());
+
+        var c = constants.get(0);
+        assertEquals(NoDoc.C, c.getElement());
+        assertEquals(new BasicDocumentSnippet(), c.getDocument());
+    }
+}

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
@@ -71,4 +71,10 @@ class DocumentedElementTest {
         assertEquals(NoDoc.C, c.getElement());
         assertEquals(new BasicDocumentSnippet(), c.getDocument());
     }
+
+    @Test
+    void constantsOf_not_enum() {
+        var constants = DocumentedElement.constantsOf(DocumentedElement.class);
+        assertEquals(List.of(), constants);
+    }
 }


### PR DESCRIPTION
This PR introduces a framework to collect document snippets of the diagnostic codes.

see the below:

* modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
  * collects diagnostic code classes, and extracts their documents.
* modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
  * shows how use `DiagnosticCodeCollector`
* modules/common/src/main/resources/META-INF/tsurugidb/diagnostic-code
  * adds diagnostic code enum class to definition file
* modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
  * adds `@Doc` annotation

