### PR TITLE
Docs register diagnostic code

### DIFF
--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceCode.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceCode.java
@@ -1,15 +1,20 @@
 package com.tsurugidb.tsubakuro.debug;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
+import com.tsurugidb.tsubakuro.util.Doc;
 
 /**
  * Code of debugging service diagnostics.
  */
+@Doc(
+        value = "Debugging service is designed to debug the database itself.",
+        note = "Please consider disabling this service for regular database use.")
 public enum DebugServiceCode implements DiagnosticCode {
 
     /**
      * Unknown error.
      */
+    @Doc("unknown error was occurred in the debugging service.")
     UNKNOWN(0),
 
     ;

--- a/modules/debug/src/main/resources/META-INF/tsurugidb/diagnostic-code
+++ b/modules/debug/src/main/resources/META-INF/tsurugidb/diagnostic-code
@@ -1,0 +1,1 @@
+com.tsurugidb.tsubakuro.debug.DebugServiceCode

--- a/modules/kvs/src/main/resources/META-INF/tsurugidb/diagnostic-code
+++ b/modules/kvs/src/main/resources/META-INF/tsurugidb/diagnostic-code
@@ -1,0 +1,1 @@
+com.tsurugidb.tsubakuro.kvs.KvsServiceCode

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceCode.java
@@ -1,20 +1,28 @@
 package com.tsurugidb.tsubakuro.auth;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
+import com.tsurugidb.tsubakuro.util.Doc;
 
 /**
  * Code of auth service diagnostics.
  */
+@Doc(
+        value = "Authentication service is designed for external use of Tsurugi's authentication mechanism.",
+        note = "This does not work correct because authentication is not yet available in Tsurugi.")
 public enum AuthServiceCode implements DiagnosticCode {
 
     /**
      * Unknown error.
      */
+    @Doc("unknown error was occurred in the authentication service.")
     UNKNOWN(0),
 
     /**
      * Authentication information is not found.
      */
+    @Doc(
+            value = "authentication information is not found in this session.",
+            note = "Credentials may be not specified when establishing a session.")
     NOT_AUTHENTICATED(1_01),
 
     ;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceCode.java
@@ -1,30 +1,36 @@
 package com.tsurugidb.tsubakuro.datastore;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
+import com.tsurugidb.tsubakuro.util.Doc;
 
 /**
  * Code of datastore service diagnostics.
  */
+@Doc("Datastore service provides the capability to manage persistent data, including backup and restore.")
 public enum DatastoreServiceCode implements DiagnosticCode {
 
     /**
      * Unknown error.
      */
+    @Doc("unknown error was occurred in the datastore service.")
     UNKNOWN(0),
 
     /**
      * Backup session is already expired.
      */
+    @Doc("the current backup session has been expired.")
     BACKUP_EXPIRED(1_01),
 
     /**
      * The target tag is already exists.
      */
+    @Doc("the tag attempted to create already exists in the database.")
     TAG_ALREADY_EXISTS(6_01),
 
     /**
      * The target tag name is too long.
      */
+    @Doc("the tag name is too long.")
     TAG_NAME_TOO_LONG(6_01),
 
     ;

--- a/modules/session/src/main/resources/META-INF/tsurugidb/diagnostic-code
+++ b/modules/session/src/main/resources/META-INF/tsurugidb/diagnostic-code
@@ -1,0 +1,3 @@
+com.tsurugidb.tsubakuro.auth.AuthServiceCode
+com.tsurugidb.tsubakuro.datastore.DatastoreServiceCode
+com.tsurugidb.tsubakuro.sql.SqlServiceCode


### PR DESCRIPTION
* registers all diagnostic code enum classes to individual definition files
* add `@Doc` annotation:
  * debugging service
  * datastore service
  * authentication service