### PR TITLE
revert cancel() invocation from ForegroundFutureResponse.close()

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
@@ -142,7 +142,6 @@ public class ForegroundFutureResponse<V> implements FutureResponse<V> {  // FIXM
     public synchronized void close() throws IOException, ServerException, InterruptedException {
         try {
             if (!gotton.getAndSet(true)) {
-                delegate.get().cancel();
                 var obj = get();
                 if (obj instanceof ServerResource) {
                     ((ServerResource) obj).close();

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionImplTest.java
@@ -282,6 +282,7 @@ class SessionImplTest {
         assertEquals("TBL", info.getTableName());
     }
 
+    @Disabled
     @Test
     void requestCancel() throws Exception {
         var session = new SessionImpl();


### PR DESCRIPTION
Cancel request will not be made for the time being due to insufficient processing of "cancel".