### PR TITLE
make sure clients know about APIs that are exposed to them but not av…

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
@@ -167,6 +167,7 @@ public final class Parameters {
     }
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Returns a new {@code BIT} parameter.
      * @param name the place-holder name
      * @param value the value
@@ -192,6 +193,7 @@ public final class Parameters {
     }
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Returns a new {@code BIT} parameter.
      * @param name the place-holder name
      * @param value the value

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableMetadata.java
@@ -8,12 +8,14 @@ import java.util.Optional;
 public interface TableMetadata extends RelationMetadata {
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Returns the database name where the table defined.
      * @return the database name, or empty if it is not set
      */
     Optional<String> getDatabaseName();
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Returns the schema name where the table defined.
      * @return the schema name, or empty if it is not set
      */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -123,6 +123,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
     }
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Executes a SQL statement with 2-dimension parameter table.
      * <p>
      * This operation may raise {@link IOException} if the 2-D parameter table is too large to send a request.


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/discussions/928

　TsubakuroのTransaction.batch()　→　done

　TransactionPriority　対応する .javaファイルなし（protocol buffersでの定義のみ）

　AtomType.BIT, BLOB, CLOB、それらに対応するPlaceholder.of(), Parameter.of()
　　Placeholder.of()や、それが使っているTypes.of()では個々のtypeを扱っているメソッドはなし
　　　なお、 https://github.com/project-tsurugi/tsubakuro/blob/7b2d0c4a73e3226a340a99528fd8432607f40115/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java#L134-L135 , https://github.com/project-tsurugi/tsubakuro/blob/7b2d0c4a73e3226a340a99528fd8432607f40115/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java#L153-L156 をコメントアウトする手もありそうだが、それは未実施。

　Parameter.of()　→　done、但し、BLOB, CLOB用のメソッドは用意されていないので、BITのみの対応。

　TableMetadata.getDatabaseName(), getSchemaName() （本来はIPC接続のデータベース名やスキーマpublicが返ってほしいが、現状はnullが返る為）　→　done