### PR TITLE
docs: add license header to java sources

### DIFF
--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/HttpTokenProvider.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/HttpTokenProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import java.io.IOException;

--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/InvalidResponseException.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/InvalidResponseException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import java.io.IOException;

--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/JwtTicketProvider.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/JwtTicketProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import java.io.IOException;

--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/MessageType.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/MessageType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import java.util.Locale;

--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/TokenProvider.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/TokenProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import java.io.IOException;

--- a/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/package-info.java
+++ b/modules/auth-http/src/main/java/com/tsurugidb/tsubakuro/auth/http/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides HTTP client for authentication service "Harinoki".
  */

--- a/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/CombinationTest.java
+++ b/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/CombinationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/HttpTokenProviderTest.java
+++ b/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/HttpTokenProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/JwtTicketProviderTest.java
+++ b/modules/auth-http/src/test/java/com/tsurugidb/tsubakuro/auth/http/JwtTicketProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.http;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProvider.java
+++ b/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.mock;
 
 import java.io.IOException;

--- a/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/package-info.java
+++ b/modules/auth-mock/src/main/java/com/tsurugidb/tsubakuro/auth/mock/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides mock implementation of authentication clients.
  */

--- a/modules/auth-mock/src/test/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProviderTest.java
+++ b/modules/auth-mock/src/test/java/com/tsurugidb/tsubakuro/auth/mock/MockTicketProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.mock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ClientInformation.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ClientInformation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.text.MessageFormat;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Connector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Connector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorFactory.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.net.URI;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorHelper.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.net.URI;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Credential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/Credential.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredential.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.io.FileNotFoundException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/ForegroundFutureResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/NullCredential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/NullCredential.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/RememberMeCredential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/RememberMeCredential.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.util.Objects;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/UsernamePasswordCredential.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/UsernamePasswordCredential.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.text.MessageFormat;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/sql/ResultSetWire.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/sql/ResultSetWire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.sql;
 
 import java.io.Closeable;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/MainResponseProcessor.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/MainResponseProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Response.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Response.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/ResponseProcessor.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/ResponseProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Wire.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Wire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/WireFactory.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/WireFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire;
 
 import java.net.URI;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/CancelMessage.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/CancelMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ChannelResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ChannelResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.ByteArrayInputStream;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/Link.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/Link.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/LinkMessage.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/LinkMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.UnsupportedEncodingException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/Queues.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/Queues.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/RequestEntry.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/RequestEntry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 class RequestEntry {

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ResponseBox.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ResponseBox.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/SlotEntry.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/SlotEntry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import javax.annotation.Nonnull;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/WireImpl.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/WireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceClient.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.client;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceClientCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceClientCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.client;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceMessageVersion.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/ServiceMessageVersion.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.client;
 
 import java.lang.annotation.Documented;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/package-info.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/client/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides clients for services on Tsurugidb.
  */

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/BrokenResponseException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/BrokenResponseException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ConnectionException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ConnectionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import java.util.EnumMap;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import java.util.Objects;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCode.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ResponseTimeoutException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ResponseTimeoutException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ServerException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/ServerException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/package-info.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides exception classes for Tsurugi services.
  */

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.Arrays;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ByteBufferInputStream.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ByteBufferInputStream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.InputStream;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ClassCollector.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ClassCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.BufferedReader;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.lang.annotation.ElementType;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.List;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentedElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.lang.reflect.Field;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/FutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/FutureResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Futures.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Futures.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.concurrent.Future;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Lang.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Lang.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.Objects;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/MappedFutureResponse.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/MappedFutureResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Owner.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Owner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Pair.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Pair.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.Optional;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResource.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResourceHolder.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResourceHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResourceNeedingDisposal.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/ServerResourceNeedingDisposal.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.util.concurrent.TimeUnit;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Timeout.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Timeout.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.IOException;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/TsubakuroVersion.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/TsubakuroVersion.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import java.io.FileNotFoundException;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/ConnectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredentialTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/FileCredentialTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/TestingConnector.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/TestingConnector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.io.IOException;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/TestingConnectorFactory.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/TestingConnectorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.channel.common.connection;
 
 import java.net.URI;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/client/MockClient.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/client/MockClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.client;
 
 /**

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/client/ServiceClientCollectorTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/client/ServiceClientCollectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/DiagnosticCodeCollectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/MockDiagnosticCode.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/exception/MockDiagnosticCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.exception;
 
 import com.tsurugidb.tsubakuro.util.Doc;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.protos;
 
 import com.tsurugidb.sql.proto.SqlCommon;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/DocumentedElementTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/TsubakuroVersionTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/TsubakuroVersionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugClient.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug;
 
 import java.io.IOException;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceCode.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceException.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/DebugServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug;
 
 import java.util.Objects;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/LogLevel.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/LogLevel.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug;
 
 import javax.annotation.Nonnull;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/Constants.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 /**

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugClientImpl.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugClientImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 import java.io.IOException;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugService.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 import java.io.IOException;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStub.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStub.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/package-info.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/impl/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Implementation of Tsurugi debugging utilities.
  */

--- a/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/package-info.java
+++ b/modules/debug/src/main/java/com/tsurugidb/tsubakuro/debug/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides Tsurugi debugging utilities.
  */

--- a/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugClientImplTest.java
+++ b/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugClientImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStubTest.java
+++ b/modules/debug/src/test/java/com/tsurugidb/tsubakuro/debug/impl/DebugServiceStubTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.debug.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/BasicPlanGraph.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/BasicPlanGraph.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.util.ArrayDeque;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/BasicPlanNode.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/BasicPlanNode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.util.ArrayList;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/DotGenerator.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/DotGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.io.IOException;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraph.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraph.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.util.Set;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphException.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import javax.annotation.Nullable;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphLoader.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.text.MessageFormat;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphUtil.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanGraphUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.util.ArrayDeque;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanNode.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/PlanNode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/AggregateExchangePropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/AggregateExchangePropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ConstantPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ConstantPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/DefaultPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/DefaultPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 /**

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/EdgeExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/EdgeExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.List;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ExecuteStatementAnalyzer.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ExecuteStatementAnalyzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Objects;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/FindPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/FindPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.LinkedHashMap;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ForwardExchangePropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ForwardExchangePropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/GroupExchangePropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/GroupExchangePropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.LinkedHashMap;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinExchangeEdgeExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinExchangeEdgeExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.List;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinFindPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinFindPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.LinkedHashMap;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinGroupPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinGroupPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinScanPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JoinScanPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.LinkedHashMap;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoader.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.text.MessageFormat;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonUtil.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/JsonUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.text.MessageFormat;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/OfferEdgeExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/OfferEdgeExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.List;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/PropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/PropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/PropertyExtractorUtil.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/PropertyExtractorUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.text.MessageFormat;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ScanPropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/ScanPropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.LinkedHashMap;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/StatementAnalyzer.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/StatementAnalyzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import javax.annotation.Nonnull;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/StepGraphAnalyzer.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/StepGraphAnalyzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.text.MessageFormat;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/TakeCogroupEdgeExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/TakeCogroupEdgeExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.ArrayList;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/TakeExchangeEdgeExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/TakeExchangeEdgeExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.List;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/WritePropertyExtractor.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/WritePropertyExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.Map;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/WriteStatementAnalyzer.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/WriteStatementAnalyzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.util.ArrayList;

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/package-info.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/json/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Execution plan analyzer for JSON style descriptors.
  */

--- a/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/package-info.java
+++ b/modules/explain/src/main/java/com/tsurugidb/tsubakuro/explain/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides models for {@code EXPLAIN} results.
  */

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/BasicPlanGraphTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/BasicPlanGraphTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/BasicPlanNodeTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/BasicPlanNodeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/DotGeneratorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/DotGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/PlanGraphUtilTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/PlanGraphUtilTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/AggregateExchangePropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/AggregateExchangePropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ConstantPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ConstantPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ExecuteStatementAnalyzerTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ExecuteStatementAnalyzerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static com.tsurugidb.tsubakuro.explain.json.TestUtil.DEFAULT_EDGE_EXTRACTORS;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/FindPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/FindPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ForwardExchangePropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ForwardExchangePropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/GroupExchangePropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/GroupExchangePropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinFindPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinFindPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinGroupPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinGroupPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinScanPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JoinScanPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoaderTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/JsonPlanGraphLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static com.tsurugidb.tsubakuro.explain.json.TestUtil.all;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/Main.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import java.io.IOException;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ScanPropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/ScanPropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/StepGraphAnalyzerTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/StepGraphAnalyzerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static com.tsurugidb.tsubakuro.explain.json.TestUtil.all;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/TestUtil.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/TestUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/WritePropertyExtractorTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/WritePropertyExtractorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/WriteStatementAnalyzerTest.java
+++ b/modules/explain/src/test/java/com/tsurugidb/tsubakuro/explain/json/WriteStatementAnalyzerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.explain.json;
 
 import static com.tsurugidb.tsubakuro.explain.json.TestUtil.TRUE;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/IpcLink.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/IpcLink.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc;
 
 import java.io.IOException;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/NativeLibrary.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/NativeLibrary.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc;
 
 import java.io.FileNotFoundException;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/FutureIpcWireImpl.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/FutureIpcWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import java.io.IOException;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorFactory.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import java.net.URI;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorImpl.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import java.io.IOException;

--- a/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ResultSetWireImpl.java
+++ b/modules/ipc/src/main/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ResultSetWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import java.io.ByteArrayInputStream;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/ConnectionTest.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/ConnectionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import java.net.ConnectException;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorFactoryTest.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/IpcConnectorFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/ServerConnectionImpl.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/connection/ServerConnectionImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.connection;
 
 import java.io.Closeable;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/CommunicationChecker.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/CommunicationChecker.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/DelimitedConverter.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/DelimitedConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ResultSetWireTest.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ResultSetWireTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ServerWireImpl.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/ServerWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import static org.junit.jupiter.api.Assertions.fail;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/SessionWireTest.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/channel/ipc/sql/SessionWireTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.ipc.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
+++ b/modules/ipc/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.protos;
 
 import com.tsurugidb.sql.proto.SqlCommon;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/BatchResult.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/BatchResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import javax.annotation.Nonnull;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/BatchScript.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/BatchScript.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.text.MessageFormat;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/CommitType.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/CommitType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/GetResult.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/GetResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.util.List;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsClient.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceCode.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.util.HashMap;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceException.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/KvsServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.util.Objects;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/PutResult.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/PutResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/PutType.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/PutType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Record.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Record.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.math.BigDecimal;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RecordBuffer.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RecordBuffer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.math.BigDecimal;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RecordCursor.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RecordCursor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RemoveResult.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RemoveResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RemoveType.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/RemoveType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/ScanBound.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/ScanBound.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/ScanType.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/ScanType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/TransactionHandle.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/TransactionHandle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/TransactionOption.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/TransactionOption.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.util.Objects;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Values.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/Values.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import java.math.BigDecimal;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/Constants.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 /**

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/GetResultImpl.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/GetResultImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.util.ArrayList;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsClientImpl.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsClientImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsService.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStub.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStub.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/PutResultImpl.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/PutResultImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.text.MessageFormat;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/RemoveResultImpl.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/RemoveResultImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.text.MessageFormat;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandleImpl.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandleImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import java.io.IOException;

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/package-info.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/impl/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Implementation of Tsurugi KVS service client.
  */

--- a/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/package-info.java
+++ b/modules/kvs/src/main/java/com/tsurugidb/tsubakuro/kvs/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides a client for Tsurugi KVS.
  */

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/KvsServiceExceptionTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/KvsServiceExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/RecordBufferTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/RecordBufferTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/RecordTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/RecordTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/ValuesTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/ValuesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/GetResultImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/GetResultImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsClientImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsClientImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/KvsServiceStubTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/PutResultImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/PutResultImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/RemoveResultImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/RemoveResultImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/StubUtils.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/StubUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandlImplTest.java
+++ b/modules/kvs/src/test/java/com/tsurugidb/tsubakuro/kvs/impl/TransactionHandlImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.kvs.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthInfo.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.text.MessageFormat;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/AuthServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.util.Objects;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/Ticket.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/Ticket.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.time.Instant;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TicketProvider.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TicketProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TokenException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TokenException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TokenKind.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/TokenKind.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/AuthClientImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/AuthClientImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/AuthServiceStub.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/AuthServiceStub.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/Constants.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/JwtTicket.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/auth/impl/JwtTicket.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 import java.time.Instant;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/AbstractFutureResponse.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/AbstractFutureResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/ShutdownType.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/ShutdownType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common;
 
 import com.tsurugidb.core.proto.CoreRequest;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/Constants.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/ServiceShelf.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/ServiceShelf.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 import java.util.LinkedHashSet;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Backup.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Backup.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupDetail.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupDetail.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupEstimate.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupEstimate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.text.MessageFormat;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupType.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/BackupType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import com.tsurugidb.datastore.proto.DatastoreRequest;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import com.tsurugidb.tsubakuro.exception.DiagnosticCode;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/DatastoreServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.util.Objects;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Tag.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/Tag.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.text.MessageFormat;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/TagList.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/TagList.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/BackupDetailImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/BackupDetailImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/BackupImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/BackupImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/Constants.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreClientImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreClientImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreServiceStub.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreServiceStub.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/impl/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Implementation of Tsurugi administration service clients.
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/datastore/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides clients for datastore service.
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/JMXAgent.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/JMXAgent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.diagnostic;
 
 import java.lang.management.ManagementFactory;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/common/SessionInfo.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/common/SessionInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.diagnostic.common;
 
 import java.util.WeakHashMap;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/common/SessionInfoMBean.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/diagnostic/common/SessionInfoMBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.diagnostic.common;
 
 public interface SessionInfoMBean {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/CounterType.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/CounterType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ExecuteResult.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ExecuteResult.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.Map;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.math.BigDecimal;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Placeholders.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Placeholders.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.text.MessageFormat;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/PreparedStatement.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/PreparedStatement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import com.tsurugidb.tsubakuro.util.ServerResourceNeedingDisposal;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/RelationCursor.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/RelationCursor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/RelationMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/RelationMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSet.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSetMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/ResultSetMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SearchPath.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SearchPath.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.EnumMap;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.Objects;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/StatementMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/StatementMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableList.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableList.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/TableMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.util.Optional;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Types.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql;
 
 import java.math.BigDecimal;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/AnalyzeException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/AnalyzeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/BlockedByConcurrentOperationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/BlockedByConcurrentOperationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/BlockedByHighPriorityTransactionException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/BlockedByHighPriorityTransactionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CcException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CcException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CheckConstraintViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CheckConstraintViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CompileException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/CompileException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ConflictOnWritePreserveException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ConflictOnWritePreserveException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ConstraintViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ConstraintViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DataCorruptionException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DataCorruptionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DependenciesViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DependenciesViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DumpDirectoryInaccessibleException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DumpDirectoryInaccessibleException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DumpFileException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/DumpFileException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/EvaluationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/EvaluationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InactiveTransactionException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InactiveTransactionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InconsistentStatementException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InconsistentStatementException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InternalException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InternalException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InvalidDecimalValueException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InvalidDecimalValueException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InvalidRuntimeValueException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/InvalidRuntimeValueException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileFormatException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileFormatException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileNotFoundException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LoadFileNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxReadException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxReadException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxWriteException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxWriteException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxWriteOperationWithoutWritePreserveException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/LtxWriteOperationWithoutWritePreserveException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/NotNullConstraintViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/NotNullConstraintViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccReadException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccReadException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccWriteException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/OccWriteException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ParameterException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ParameterException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ReadOperationOnRestrictedReadAreaException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ReadOperationOnRestrictedReadAreaException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ReferentialIntegrityConstraintViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ReferentialIntegrityConstraintViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RequestFailureException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RequestFailureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RestrictedOperationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RestrictedOperationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RtxException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/RtxException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ScalarSubqueryEvaluationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ScalarSubqueryEvaluationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SecondaryIndexCorruptionException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SecondaryIndexCorruptionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlExecutionException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlExecutionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlLimitReachedException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlLimitReachedException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlRequestTimeoutException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SqlRequestTimeoutException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/StatementNotFoundException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/StatementNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SymbolAnalyzeException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SymbolAnalyzeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SyntaxException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/SyntaxException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TargetAlreadyExistsException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TargetAlreadyExistsException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TargetNotFoundException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TargetNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TransactionExceededLimitException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TransactionExceededLimitException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TransactionNotFoundException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TransactionNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TypeAnalyzeException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/TypeAnalyzeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UniqueConstraintViolationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UniqueConstraintViolationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnresolvedPlaceholderException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnresolvedPlaceholderException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnsupportedCompilerFeatureException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnsupportedCompilerFeatureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnsupportedRuntimeFeatureException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/UnsupportedRuntimeFeatureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueAnalyzeException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueAnalyzeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueEvaluationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueEvaluationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueOutOfRangeException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueOutOfRangeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueTooLongException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/ValueTooLongException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/WriteOperationByRtxException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/exception/WriteOperationByRtxException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.exception;
 
 import javax.annotation.Nonnull;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/AbstractResultSetProcessor.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/AbstractResultSetProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/BasicStatementMetadata.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/BasicStatementMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/Constants.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/EmptyRelationCursor.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/EmptyRelationCursor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.math.BigDecimal;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ExecuteResultAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ExecuteResultAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/PreparedStatementImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/PreparedStatementImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetMetadataAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ResultSetMetadataAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SearchPathAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SearchPathAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlClientImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlClientImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStub.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/StatementMetadataAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/StatementMetadataAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TableListAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TableListAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TableMetadataAdapter.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TableMetadataAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.util.List;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ValueInputBackedRelationCursor.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/ValueInputBackedRelationCursor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Implementation of SQL service client.
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/Base128Variant.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/Base128Variant.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BitBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BitBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.util.Arrays;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BrokenEncodingException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BrokenEncodingException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BrokenRelationException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BrokenRelationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ByteBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ByteBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.util.Arrays;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/Constants.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/Constants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.math.BigInteger;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/DateTimeInterval.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/DateTimeInterval.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.math.BigDecimal;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/EntryType.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/EntryType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueInput.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueInput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import static com.tsurugidb.tsubakuro.sql.io.Constants.HEADER_ARRAY;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueOutput.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import static com.tsurugidb.tsubakuro.sql.io.Constants.HEADER_ARRAY;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ValueInput.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ValueInput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ValueOutput.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/ValueOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides SQL data input/output.
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  *
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/Load.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/Load.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.util;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.util;
 
 import java.io.IOException;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/package-info.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/util/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Utilities for Tsurugi SQL service.
  */

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/auth/impl/AuthClientImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/auth/impl/AuthClientImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/auth/impl/JwtTicketTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/auth/impl/JwtTicketTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.auth.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/SessionBuilderTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/SessionBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/MockError.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/MockError.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 /**

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/MockWire.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/MockWire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/RequestHandler.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/RequestHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/SessionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/SessionImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.common.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreClientImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/datastore/impl/DatastoreClientImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/datastore/impl/SessionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/datastore/impl/SessionImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.datastore.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/session/ProtosForTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/session/ProtosForTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.session;
 
 import com.tsurugidb.sql.proto.SqlCommon;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/AbstractFutureResponse.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/AbstractFutureResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/DelimitedConverter.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/DelimitedConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/FutureResponseMock.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/FutureResponseMock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/MockError.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/MockError.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 /**

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/MockWire.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/MockWire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/ParametersTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/ParametersTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/PlaceholdersTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/PlaceholdersTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/RequestHandler.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/RequestHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionExceptionTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SessionImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SimpleResponse.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SimpleResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import java.io.IOException;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStubTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/SqlServiceStubTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionExceptionTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TransactionImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TypesTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/impl/TypesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/Base128VariantTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/Base128VariantTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueInputTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueInputTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueOutputTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/io/StreamBackedValueOutputTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.io;
 
 import static com.tsurugidb.tsubakuro.sql.io.Constants.HEADER_ARRAY;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilderTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/sql/util/LoadBuilderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/ErroneousWire.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/ErroneousWire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.mock;
 
 import java.net.URI;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockError.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockError.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.mock;
 
 /**

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/MockWire.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.mock;
 
 import java.io.IOException;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/RequestHandler.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/RequestHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.mock;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/SimpleResponse.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/SimpleResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.mock;
 
 import java.io.IOException;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/package-info.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/mock/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Provides mock classes.
  */

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/BasicResultSet.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/BasicResultSet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.io.IOException;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Entry.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Entry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.math.BigDecimal;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/EntrySequenceValueInput.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/EntrySequenceValueInput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.math.BigDecimal;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/EntrySequenceValueOutput.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/EntrySequenceValueOutput.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.math.BigDecimal;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Relation.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/Relation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package  com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/ResultSetWireMock.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/ResultSetWireMock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.sql.impl.testing;
 
 import java.io.IOException;

--- a/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/package-info.java
+++ b/modules/session/src/testFixtures/java/com/tsurugidb/tsubakuro/sql/impl/testing/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Testing utilities about Tsubakuro SQL features.
  */

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/StreamLink.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/StreamLink.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream;
 
 import java.io.DataInputStream;

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/FutureStreamWireImpl.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/FutureStreamWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.connection;
 
 import java.io.IOException;

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorFactory.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.connection;
 
 import java.net.URI;

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorImpl.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.connection;
 
 import java.io.IOException;

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/sql/ResultSetBox.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/sql/ResultSetBox.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import java.io.IOException;

--- a/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/sql/ResultSetWireImpl.java
+++ b/modules/stream/src/main/java/com/tsurugidb/tsubakuro/channel/stream/sql/ResultSetWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import java.io.IOException;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/ServerStreamLink.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/ServerStreamLink.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream;
 
 import java.io.DataInputStream;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorFactoryTest.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/connection/StreamConnectorFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.connection;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/CommunicationChecker.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/CommunicationChecker.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/DelimitedConverter.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/DelimitedConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import java.io.ByteArrayOutputStream;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/ServerWireImpl.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/ServerWireImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import java.io.ByteArrayInputStream;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/SessionWireTest.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/sql/SessionWireTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.channel.stream.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/protos/ProtosForTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tsurugidb.tsubakuro.protos;
 
 import com.tsurugidb.sql.proto.SqlCommon;


### PR DESCRIPTION
This pull pequest adding license header to the java source code using #477 build feature.