### PR TITLE
fix: rethrow CoreServiceException

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceException.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceException.java
@@ -31,9 +31,10 @@ public class CoreServiceException extends ServerException {
 
     /**
      * Creates a new instance.
-     * @param code the diagnostic code
+     *
+     * @param code    the diagnostic code
      * @param message the error message
-     * @param cause the original cause
+     * @param cause   the original cause
      */
     public CoreServiceException(@Nonnull CoreServiceCode code, @Nullable String message, @Nullable Throwable cause) {
         super(buildMessage(code, message), cause);
@@ -50,6 +51,7 @@ public class CoreServiceException extends ServerException {
 
     /**
      * Creates a new instance.
+     *
      * @param code the diagnostic code
      */
     public CoreServiceException(@Nonnull CoreServiceCode code) {
@@ -58,7 +60,8 @@ public class CoreServiceException extends ServerException {
 
     /**
      * Creates a new instance.
-     * @param code the diagnostic code
+     *
+     * @param code    the diagnostic code
      * @param message the error message
      */
     public CoreServiceException(@Nonnull CoreServiceCode code, @Nullable String message) {
@@ -67,15 +70,31 @@ public class CoreServiceException extends ServerException {
 
     /**
      * Creates a new instance.
-     * @param code the diagnostic code
+     *
+     * @param code  the diagnostic code
      * @param cause the original cause
      */
     public CoreServiceException(@Nonnull CoreServiceCode code, @Nullable Throwable cause) {
         this(code, null, cause);
     }
 
+    private CoreServiceException(CoreServiceException cause) {
+        super(cause.getMessage(), cause);
+        this.code = cause.code;
+    }
+
     @Override
     public CoreServiceCode getDiagnosticCode() {
         return code;
+    }
+
+    /**
+     * Creates a new instance wrapped itself.
+     *
+     * @return exception wrapped itself
+     * @since 1.7.0
+     */
+    public CoreServiceException newException() {
+        return new CoreServiceException(this);
     }
 }

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ChannelResponseTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/ChannelResponseTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-2024 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tsurugidb.tsubakuro.channel.common.connection.wire.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.tsubakuro.exception.CoreServiceCode;
+import com.tsurugidb.tsubakuro.exception.CoreServiceException;
+import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
+import com.tsurugidb.tsubakuro.exception.ResponseTimeoutException;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+
+class ChannelResponseTest {
+
+    @Test
+    void wrapAndThrow() throws Exception {
+        try (var target = new ChannelResponse(null)) {
+            {
+                var e0 = new CoreServiceException(CoreServiceCode.SYSTEM_ERROR, "test");
+                var e = assertThrows(ServerException.class, () -> {
+                    target.wrapAndThrow(e0);
+                });
+                assertEquals(e0.getClass(), e.getClass());
+                assertEquals(e0.getDiagnosticCode(), e.getDiagnosticCode());
+                assertEquals(e0.getMessage(), e.getMessage());
+                assertSame(e0, e.getCause());
+            }
+            {
+                var e0 = new TestServerException(CoreServiceCode.SYSTEM_ERROR, "test");
+                var e = assertThrows(IOException.class, () -> {
+                    target.wrapAndThrow(e0);
+                });
+                assertEquals(e0.getMessage(), e.getMessage());
+                assertSame(e0, e.getCause());
+            }
+            {
+                var e0 = new TimeoutException("test");
+                var e = assertThrows(IOException.class, () -> {
+                    target.wrapAndThrow(e0);
+                });
+                assertEquals(ResponseTimeoutException.class, e.getClass());
+                assertEquals(e0.getMessage(), e.getMessage());
+                assertSame(e0, e.getCause());
+            }
+            {
+                var e0 = new IOException("test");
+                target.wrapAndThrow(e0); // do nothing
+            }
+        }
+    }
+
+    @SuppressWarnings("serial")
+    private static class TestServerException extends ServerException {
+
+        private final DiagnosticCode code;
+
+        public TestServerException(DiagnosticCode code, String message) {
+            super(message);
+            this.code = code;
+        }
+
+        @Override
+        public DiagnosticCode getDiagnosticCode() {
+            return this.code;
+        }
+    }
+}


### PR DESCRIPTION
fix: rethrow CoreServiceException
BREAKING CHANGE: In ChannelResponse, IOException was thrown, but changed to CoreServiceException.