### PR TITLE
ci: modify runs-on for preventing ubuntu-latest

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -5,7 +5,7 @@ concurrency: ${{ github.workflow }}
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
As ubuntu 24.04 is currently still experimental support

See: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes