### PR TITLE
Add javadoc about executeDump(String, Path) is not yet implemented

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Transaction.java
@@ -121,6 +121,7 @@ public interface Transaction extends ServerResourceNeedingDisposal {
     }
 
     /**
+     * <em>This method is not yet implemented:</em>
      * Executes a dump action.
      * <p>
      * This operation just executes a query, but will write the resulting relation data into dump files


### PR DESCRIPTION
This pull request includes a minor documentation update to the `Transaction.java` file. The change adds a note indicating that the `executeQuery(String, Path)` is not yet implemented.
