### PR TITLE
build: show resolved jni libraries for building Tsubakuro Native

### DIFF
--- a/modules/ipc/src/main/native/CMakeLists.txt
+++ b/modules/ipc/src/main/native/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
     set(JAVA_AWT_INCLUDE_PATH NotNeeded)
     find_package(JNI REQUIRED)
 endif()
+message (STATUS "JNI_LIBRARIES: ${JNI_LIBRARIES}")
 
 include_directories(${JNI_INCLUDE_DIRS})
 


### PR DESCRIPTION
This pull request includes a small change to the `modules/ipc/src/main/native/CMakeLists.txt` file. A message was added to display the value of `JNI_LIBRARIES` during the build process.