### PR TITLE
build: add showToolchainJavaHome Gradle task

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -11,6 +11,14 @@ java {
     }
 }
 
+task showToolchainJavaHome {
+    doLast {
+        var jdk = javaToolchains.compilerFor(java.toolchain).get()
+        var home = jdk.metadata.installationPath.asFile
+        println(home)
+    }
+}
+
 ext {
     tsubakuroVersion = "${project.version}"
     isReleaseVersion = !version.endsWith("SNAPSHOT")


### PR DESCRIPTION
This pull request adds a new Gradle task to the `java-base` build script for displaying the Java toolchain's installation path.

Build script enhancement:

* [`buildSrc/src/main/groovy/tsubakuro.java-base.gradle`](diffhunk://#diff-aacf013a0d3af8beecbbe1fb58b09e1ec6b7829305f9e2224a6bbf2a4be615b9R14-R21): Introduced a new task `showToolchainJavaHome` that prints the `installationPath` of the configured Java toolchain. This can be useful to build JNI library in tsubakuro-ipc