### PR TITLE
Fix to fail Gradle `PublishToMavenLocal` task with Release Version

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish
         run: |
-          ./gradlew -i clean publish
+          ./gradlew -i clean publish -PenableSign
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USER }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7'
     implementation 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
-    implementation 'com.vanniktech:gradle-maven-publish-plugin:0.32.0'
+    implementation 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
 }

--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -22,6 +22,7 @@ task showToolchainJavaHome {
 ext {
     tsubakuroVersion = "${project.version}"
     isReleaseVersion = !version.endsWith("SNAPSHOT")
+    isSignEnabled = project.hasProperty('enableSign')
     buildTimestamp = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
     buildRevision = System.getenv("GITHUB_SHA") ?: ""
     createdBy = "Gradle ${gradle.gradleVersion}"

--- a/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
@@ -12,7 +12,7 @@ mavenPublishing {
     configure(new JavaLibrary(new JavadocJar.None(), true))
     publishToMavenCentral()
 
-    if (isReleaseVersion) {
+    if (isReleaseVersion && isSignEnabled) {
         signAllPublications()
     }
 

--- a/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-library-conventions.gradle
@@ -5,13 +5,12 @@ plugins {
     id 'tsubakuro.java-conventions'
 }
 
-import com.vanniktech.maven.publish.SonatypeHost
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
 mavenPublishing {
     configure(new JavaLibrary(new JavadocJar.None(), true))
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     if (isReleaseVersion) {
         signAllPublications()


### PR DESCRIPTION
This Pull Request fixes a bug where Gradle's `PublishToMavenLocal` task fails when executed for release versions.

This also bumps `vanniktech:gradle-maven-publish-plugin` to 0.34.0.
