### PR TITLE
introduce numeric diagnostic type code to `SCD-*` and `SQL-*`.

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/exception/CoreServiceCode.java
@@ -26,7 +26,9 @@ import com.tsurugidb.tsubakuro.util.Doc;
 /**
  * Code of server core diagnostics.
  */
-@Doc("diagnostics of the service infrastructure.")
+@Doc(
+    value = "diagnostics of the service infrastructure.",
+    code = 1)
 public enum CoreServiceCode implements DiagnosticCode {
 
     /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippet.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -26,6 +27,7 @@ import javax.annotation.Nullable;
 
 /**
  * A basic implementation of {@link DocumentSnippet}.
+ * @version 1.7.0
  */
 public class BasicDocumentSnippet implements DocumentSnippet {
 
@@ -35,29 +37,48 @@ public class BasicDocumentSnippet implements DocumentSnippet {
 
     private final List<Reference> references;
 
+    private final @Nullable Integer code;
+
     /**
      * Creates an empty instance.
      */
     public BasicDocumentSnippet() {
-        this(List.of(), List.of(), List.of());
+        this(List.of(), List.of(), List.of(), null);
     }
 
     /**
      * Creates a new instance.
      * @param description the description in the document snippet
-     * @param notes additional notesin the document snippet
+     * @param notes additional notes in the document snippet
      * @param references optional references in the document snippet
      */
     public BasicDocumentSnippet(
             @Nonnull List<? extends String> description,
             @Nonnull List<? extends String> notes,
             @Nonnull List<? extends Reference> references) {
+        this(description, notes, references, null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param description the description in the document snippet
+     * @param notes additional notes in the document snippet
+     * @param references optional references in the document snippet
+     * @param code an optional code number for the target element
+     * @since 1.7.0
+     */
+    public BasicDocumentSnippet(
+            @Nonnull List<? extends String> description,
+            @Nonnull List<? extends String> notes,
+            @Nonnull List<? extends Reference> references,
+            @Nullable Integer code) {
         Objects.requireNonNull(description);
         Objects.requireNonNull(notes);
         Objects.requireNonNull(references);
         this.description = List.copyOf(description);
         this.notes = List.copyOf(notes);
         this.references = List.copyOf(references);
+        this.code = code;
     }
 
     /**
@@ -90,7 +111,11 @@ public class BasicDocumentSnippet implements DocumentSnippet {
                     return new BasicReference(location, title);
                 })
                 .collect(Collectors.toList());
-        return new BasicDocumentSnippet(description, notes, references);
+        Integer code = null;
+        if (annotation.code() != Doc.CODE_UNSPECIFIED) {
+            code = annotation.code();
+        }
+        return new BasicDocumentSnippet(description, notes, references, code);
     }
 
     @Override
@@ -109,8 +134,16 @@ public class BasicDocumentSnippet implements DocumentSnippet {
     }
 
     @Override
+    public OptionalInt getCode() {
+        if (code != null) {
+            return OptionalInt.of(code);
+        }
+        return OptionalInt.empty();
+    }
+
+    @Override
     public int hashCode() {
-        return Objects.hash(description, notes, references);
+        return Objects.hash(description, notes, references, code);
     }
 
     @Override
@@ -127,13 +160,14 @@ public class BasicDocumentSnippet implements DocumentSnippet {
         BasicDocumentSnippet other = (BasicDocumentSnippet) obj;
         return Objects.equals(description, other.description)
                 && Objects.equals(notes, other.notes)
-                && Objects.equals(references, other.references);
+                && Objects.equals(references, other.references)
+                && Objects.equals(code, other.code);
     }
 
     @Override
     public String toString() {
-        return String.format("BasicDocumentSnippet(description=%s, notes=%s, references=%s)", //$NON-NLS-1$
-                description, notes, references);
+        return String.format("BasicDocumentSnippet(description=%s, notes=%s, references=%s, code=%s)", //$NON-NLS-1$
+                description, notes, references, code);
     }
 
     /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/Doc.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Target;
  * For example, to attach this annotation to the definition of each structured error codes,
  * then you can easily create a table of those codes.
  * </p>
+ * @version 1.7.0
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({
@@ -41,6 +42,12 @@ public @interface Doc {
      * A delimiter character to separate reference title and its location.
      */
     char REFERENCE_DELIMITER = '@';
+
+    /**
+     * An unspecified value for {@link #code()}.
+     * @since 1.7.0
+     */
+    int CODE_UNSPECIFIED = -1;
 
     /**
      * Description of the target element.
@@ -67,4 +74,12 @@ public @interface Doc {
      * @see #REFERENCE_DELIMITER
      */
     String[] reference() default {};
+
+    /**
+     * An optional code number for the target element.
+     * @return the element code if defined, otherwise {@link #CODE_UNSPECIFIED}
+     * @see #CODE_UNSPECIFIED
+     * @since 1.7.0
+     */
+    int code() default CODE_UNSPECIFIED;
 }

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/util/DocumentSnippet.java
@@ -17,10 +17,12 @@ package com.tsurugidb.tsubakuro.util;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Represents a snippet of documentation, reflects to {@link Doc}.
  * @see Doc
+ * @version 1.7.0
  */
 public interface DocumentSnippet {
 
@@ -44,6 +46,15 @@ public interface DocumentSnippet {
      */
     default List<Reference> getReferences() {
         return List.of();
+    }
+
+    /**
+     * Returns an optional code number for the target element.
+     * @return the element code if defined, otherwise {@code empty}
+     * @since 1.7.0
+     */
+    default OptionalInt getCode() {
+        return OptionalInt.empty();
     }
 
     /**

--- a/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
+++ b/modules/common/src/test/java/com/tsurugidb/tsubakuro/util/BasicDocumentSnippetTest.java
@@ -15,10 +15,10 @@
  */
 package com.tsurugidb.tsubakuro.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +37,7 @@ class BasicDocumentSnippetTest {
     @Test
     void new_empty() {
         var doc = new BasicDocumentSnippet();
-        assertEquals(new BasicDocumentSnippet(List.of(), List.of(), List.of()), doc);
+        assertEquals(new BasicDocumentSnippet(List.of(), List.of(), List.of(), null), doc);
     }
 
     @Doc("OK")
@@ -129,5 +129,36 @@ class BasicDocumentSnippetTest {
                                 new BasicDocumentSnippet.BasicReference("http://example.com/3", null))),
                 doc,
                 doc.toString());
+    }
+
+    @Doc(value = "OK", code = 123)
+    @Test
+    void of_code() {
+        var a = pick("of_code");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of(),
+                        123),
+                doc,
+                doc.toString());
+        assertEquals(OptionalInt.of(123), doc.getCode());
+    }
+
+    @Doc(value = "OK", code = Doc.CODE_UNSPECIFIED)
+    @Test
+    void of_code_unspecified() {
+        var a = pick("of_code_unspecified");
+        var doc = BasicDocumentSnippet.of(a);
+        assertEquals(
+                new BasicDocumentSnippet(
+                        List.of("OK"),
+                        List.of(),
+                        List.of()),
+                doc,
+                doc.toString());
+        assertEquals(OptionalInt.empty(), doc.getCode());
     }
 }

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/SqlServiceCode.java
@@ -20,14 +20,16 @@ import java.util.EnumMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
 import com.tsurugidb.sql.proto.SqlError;
+import com.tsurugidb.tsubakuro.exception.DiagnosticCode;
 import com.tsurugidb.tsubakuro.util.Doc;
 
 /**
  * Code of server core diagnostics.
  */
-@Doc(value = "SQL service is designed to access the database with SQL.")
+@Doc(
+    value = "SQL service is designed to access the database with SQL.",
+    code = 2)
 public enum SqlServiceCode implements DiagnosticCode {
 
     /**
@@ -317,7 +319,7 @@ public enum SqlServiceCode implements DiagnosticCode {
      */
     @Doc("unsupported feature/syntax was requested")
     UNSUPPORTED_COMPILER_FEATURE_EXCEPTION(3010, SqlError.Code.UNSUPPORTED_COMPILER_FEATURE_EXCEPTION),
-    
+
     /**
      * CC_EXCEPTION
      */
@@ -359,7 +361,7 @@ public enum SqlServiceCode implements DiagnosticCode {
      */
     @Doc("LTX aborted due to its read")
     LTX_READ_EXCEPTION(4013, SqlError.Code.LTX_READ_EXCEPTION),
-    
+
     /**
      * LTX_WRITE_EXCEPTION
      */


### PR DESCRIPTION
This PR introduces a numeric diagnostic type code to `CoreDiagnosticCode` and `SqlServiceCode`, and adds support for associating an optional numeric code with documentation snippets via the `@Doc` annotation and related classes.

This numeric diagnostic type code is mainly designed for other connection libraries (e.g., ODBC and JDBC).

>[!WARNING]
> This change will introduce into Tsubakuro 1.7.0.

Key changes:

**API and Annotation Enhancements:**
- Added a `code` attribute to the `@Doc` annotation, along with a constant `CODE_UNSPECIFIED` to indicate when the code is not set. [[1]](diffhunk://#diff-64526a11e03556914d79454b4b66b7025a08a75caee151362cb1376a74f87d51R46-R51) [[2]](diffhunk://#diff-64526a11e03556914d79454b4b66b7025a08a75caee151362cb1376a74f87d51R77-R84)
- Updated `CoreServiceCode` and `SqlServiceCode` enums to specify the new `code` attribute in their `@Doc` annotations. [[1]](diffhunk://#diff-b5e30be413d71110444c4582ec52062e4302e7bc76b3ce54ca37abd1fce90b64L29-R31) [[2]](diffhunk://#diff-119b1fd36638441af12af03c75f7f48b7e96aff49108f5714edfe2cc71235553L23-R32)

**Interface and Implementation Updates:**
- Extended the `DocumentSnippet` interface to include a new `getCode()` method that returns an `OptionalInt` representing the code number if present. [[1]](diffhunk://#diff-86a1bb7e5bda9d465aa685015fc581a800f8f0b16e717317e1cfaed71ead6ebcR20-R25) [[2]](diffhunk://#diff-86a1bb7e5bda9d465aa685015fc581a800f8f0b16e717317e1cfaed71ead6ebcR51-R59)
- Updated `BasicDocumentSnippet` to store and handle the optional code, including new constructors, implementation of `getCode()`, and updates to `equals`, `hashCode`, and `toString`. [[1]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395R22-R30) [[2]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395R40-R46) [[3]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395R59-R81) [[4]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395L93-R118) [[5]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395R136-R146) [[6]](diffhunk://#diff-f1cd54e72eee5d4d51dacbdcabd75fa107baf01fbf6cfafc00211fa2092fd395L130-R170)

**Testing:**
- Expanded unit tests in `BasicDocumentSnippetTest` to verify correct handling of the new code attribute, including cases where the code is specified and unspecified. [[1]](diffhunk://#diff-4d6c7056e32ca8a07e00b36e90e7952284fb11b62d15505556fdf14e7741ff32L18-R21) [[2]](diffhunk://#diff-4d6c7056e32ca8a07e00b36e90e7952284fb11b62d15505556fdf14e7741ff32L40-R40) [[3]](diffhunk://#diff-4d6c7056e32ca8a07e00b36e90e7952284fb11b62d15505556fdf14e7741ff32R133-R163)