### PR TITLE
Release 1.14.0 snapshot

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.tsurugidb.tsubakuro'
-version = '1.13.0-SNAPSHOT'
+version = '1.13.0'
 
 java {
     toolchain {

--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.tsurugidb.tsubakuro'
-version = '1.13.0'
+version = '1.14.0-SNAPSHOT'
 
 java {
     toolchain {


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1392

This PR updates the project version from 1.13.0-SNAPSHOT to 1.14.0-SNAPSHOT, preparing for the next minor release cycle.
* Version bump to 1.14.0-SNAPSHOT in the gradle build configuration