### PR TITLE
build: Upgrade build toolchain to JDK 17 with Java 11 target compatibility

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 ## Requirements
 
 ### JDK
-* OpenJDK 11 (see https://docs.microsoft.com/ja-jp/java/openjdk/download)
-The environment variables JAVA_HOME and PATH should be as follows;
-set JAVA_HOME to the directory where the JDK is installed,
-and add the directory where the java command exists to PATH.
+Tsubakuro needs JDK 17 to build.
+
+**Note:** The build is configured with `release = 11` in Gradle, which means the compiled bytecode is compatible with Java 11 or later. While JDK 17 is required for the build environment, the resulting JAR files can run on Java 11 and above.
 
 ### Dependency packages for Native Library
 Tsubakuro needs to install several packages for Native Libarary builds.
@@ -17,7 +16,7 @@ See *Dockerfile* section.
 ```dockerfile
 FROM ubuntu:22.04
 
-RUN apt update -y && apt install -y git build-essential cmake libboost-system-dev openjdk-11-jdk
+RUN apt update -y && apt install -y git build-essential cmake libboost-system-dev openjdk-17-jdk
 ```
 
 ###

--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -7,7 +7,7 @@ version = '1.14.0-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -31,6 +31,7 @@ ext {
 }
 
 tasks.withType(JavaCompile) { task ->
+    options.release = 11
     task.options.encoding 'UTF-8'
 }
 


### PR DESCRIPTION
This pull request updates the project to require JDK 17 for building, while maintaining compatibility with Java 11 for running the resulting artifacts. The changes ensure the build environment, CI workflows, and documentation are all aligned with this new requirement.

**Build and CI configuration updates:**

* Updated the Java toolchain version in `tsubakuro.java-base.gradle` to use JDK 17 for builds, and explicitly set the compiled bytecode to target Java 11 for runtime compatibility. [[1]](diffhunk://#diff-aacf013a0d3af8beecbbe1fb58b09e1ec6b7829305f9e2224a6bbf2a4be615b9L10-R10) [[2]](diffhunk://#diff-aacf013a0d3af8beecbbe1fb58b09e1ec6b7829305f9e2224a6bbf2a4be615b9R34)
* Changed the Java version in GitHub Actions workflows (`ci-build.yml` and `ci-publish.yml`) from 11 to 17 to match the new build requirement. [[1]](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdL26-R26) [[2]](diffhunk://#diff-c0376e8658cc58d36eac64ec306063469da993fa69c79b4cf0f8e2445a3874efL21-R21)

**Documentation updates:**

* Revised the `README.md` to state that JDK 17 is now required for building, clarified the use of `release = 11` for runtime compatibility, and updated the Dockerfile example to use `openjdk-17-jdk`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R19)