### PR TITLE
close LargeObjectClient at session close

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -44,6 +44,7 @@ import com.tsurugidb.blob_relay.proto.Streaming;
  * BlobRelayStreaming is a class that provides methods for streaming Blob data using gRPC.
  */
 public class BlobRelayStreaming implements Closeable {
+    private static final long CLOSE_TIMEOUT = 1_000; // 1 second
     private final BlobRelayStreamingGrpc.BlobRelayStreamingStub stub;
     private final long chunkSize;
     private final ManagedChannel channel;
@@ -69,7 +70,15 @@ public class BlobRelayStreaming implements Closeable {
 
     @Override
     public void close() {
-        channel.shutdownNow();
+        channel.shutdown();
+        try {
+            if (!channel.awaitTermination(CLOSE_TIMEOUT, TimeUnit.MILLISECONDS)) {
+                channel.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channel.shutdownNow();
+        }
     }
 
     /**
@@ -156,9 +165,17 @@ public class BlobRelayStreaming implements Closeable {
         } finally {
             lock.unlock();
         }
-        if (error.get() != null) {
-            channel.shutdownNow();
-            throw new RuntimeException(error.get());
+        Throwable cause = error.get();
+        if (cause != null) {
+            close();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw (InterruptedException) cause;
+            }
+            throw new IOException("Failed to retrieve blob data", cause);
         }
         return reference.get();
     }
@@ -266,9 +283,17 @@ public class BlobRelayStreaming implements Closeable {
         } finally {
             lock.unlock();
         }
-        if (error.get() != null) {
-            channel.shutdownNow();
-            throw new RuntimeException(error.get());
+        Throwable cause = error.get();
+        if (cause != null) {
+            close();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw (InterruptedException) cause;
+            }
+            throw new IOException("Failed to retrieve blob data", cause);
         }
 
         // check the metadata and total bytes

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -69,7 +69,7 @@ public class BlobRelayStreaming implements Closeable {
 
     @Override
     public void close() {
-        channel.shutdown();
+        channel.shutdownNow();
     }
 
     /**
@@ -84,6 +84,7 @@ public class BlobRelayStreaming implements Closeable {
      */
     public BlobRelayCommon.BlobReference put(Streaming.PutStreamingRequest.Metadata meta, InputStream input, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
         final AtomicReference<BlobRelayCommon.BlobReference> reference = new AtomicReference<>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
         final AtomicBoolean completed = new AtomicBoolean(false);
         final Lock lock = new ReentrantLock();
         final Condition condition = lock.newCondition();
@@ -98,6 +99,7 @@ public class BlobRelayStreaming implements Closeable {
             public void onError(Throwable t) {
                 lock.lock();
                 try {
+                    error.set(t);
                     completed.set(true);
                     condition.signalAll();
                 } finally {
@@ -154,6 +156,10 @@ public class BlobRelayStreaming implements Closeable {
         } finally {
             lock.unlock();
         }
+        if (error.get() != null) {
+            channel.shutdownNow();
+            throw new RuntimeException(error.get());
+        }
         return reference.get();
     }
 
@@ -179,9 +185,10 @@ public class BlobRelayStreaming implements Closeable {
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
     public void get(Streaming.GetStreamingRequest request, OutputStream outputStream, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
-        AtomicReference<Streaming.GetStreamingResponse.Metadata> reference = new AtomicReference<>();
-        AtomicLong totalBytes = new AtomicLong(0);
-        AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicReference<Streaming.GetStreamingResponse.Metadata> reference = new AtomicReference<>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicLong totalBytes = new AtomicLong(0);
+        final AtomicBoolean completed = new AtomicBoolean(false);
         Lock lock = new ReentrantLock();
         Condition condition = lock.newCondition();
 
@@ -214,6 +221,7 @@ public class BlobRelayStreaming implements Closeable {
                 // Handle the error
                 lock.lock();
                 try {
+                    error.set(t);
                     completed.set(true);
                     condition.signalAll();
                 } finally {
@@ -257,6 +265,10 @@ public class BlobRelayStreaming implements Closeable {
             }
         } finally {
             lock.unlock();
+        }
+        if (error.get() != null) {
+            channel.shutdownNow();
+            throw new RuntimeException(error.get());
         }
 
         // check the metadata and total bytes

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
@@ -665,6 +665,9 @@ public class SessionImpl implements Session {
                     if (closed.compareAndSet(expected, SESSION_CLOSED)) {
                         keepAliveTimer.cancel();  // does not throw any exception
                         wireClose();
+                        if (largeObjectClient != null) {
+                            largeObjectClient.close();
+                        }
                         close();                  // in case close() is not called yet, and thus disposer is not terminated yet
                         return;
                     }

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
@@ -664,9 +664,12 @@ public class SessionImpl implements Session {
                 try {
                     if (closed.compareAndSet(expected, SESSION_CLOSED)) {
                         keepAliveTimer.cancel();  // does not throw any exception
-                        wireClose();
-                        if (largeObjectClient != null) {
-                            largeObjectClient.close();
+                        try {
+                            wireClose();
+                        } finally {
+                            if (largeObjectClient != null) {
+                                largeObjectClient.close();
+                            }
                         }
                         close();                  // in case close() is not called yet, and thus disposer is not terminated yet
                         return;


### PR DESCRIPTION
Fixes a resource-lifecycle bug (tsurugi-issues#1401) by ensuring the session’s Large Object transfer client is closed as part of session shutdown/close, and tightens gRPC relay cleanup/error handling to avoid leaving streaming resources running.

**Changes:**
- Close `largeObjectClient` when the session transitions to `SESSION_CLOSED`.
- Make `BlobRelayStreaming.close()` terminate the gRPC channel more aggressively (`shutdownNow()`).
- Track streaming RPC errors in `BlobRelayStreaming` and fail the caller when `onError()` is invoked.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401