### PR TITLE
fix the behavior of BlobTransferType.DOES_NOT_USE case

### DIFF
--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/WireImpl.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/impl/WireImpl.java
@@ -365,6 +365,7 @@ public class WireImpl implements Wire {
                         }
                         break;
                     case BLOBTRANSFER_NOT_SET:
+                        blobTransferMedium = new BlobTransferMediumImpl(BlobTransferType.DOES_NOT_USE);
                         break;
                     default:
                         throw new AssertionError("unsupported blob transfer medium: " + successMessage.getBlobTransferCase());

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
@@ -30,8 +30,11 @@ import com.tsurugidb.tsubakuro.common.exception.BlobException;
 import com.tsurugidb.tsubakuro.util.FutureResponse;
 
 /**
- * An implementation of {@link LargeObjectClient} that provides privileged access to the Large Object storage.
- * This client is used when the endpoint supports privileged access and the session is configured to use privileged transfer type.
+ * A void/disabled implementation of {@link LargeObjectClient}.
+ * This client represents the absence of Large Object (BLOB) support in the current session,
+ * such as when the session is configured not to use a Large Object transfer medium
+ * (for example, {@code DOES_NOT_USE} / no medium).
+ * All operations are unavailable and will throw {@link IllegalStateException}.
  *
  * @since 1.11.0
  */

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tsurugidb.tsubakuro.common.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Path;
+
+import javax.annotation.Nonnull;
+
+import com.tsurugidb.tsubakuro.common.LargeObjectCache;
+import com.tsurugidb.tsubakuro.common.LargeObjectClient;
+import com.tsurugidb.tsubakuro.common.LargeObjectInfo;
+import com.tsurugidb.tsubakuro.common.LargeObjectReference;
+import com.tsurugidb.tsubakuro.common.exception.BlobException;
+import com.tsurugidb.tsubakuro.util.FutureResponse;
+
+/**
+ * An implementation of {@link LargeObjectClient} that provides privileged access to the Large Object storage.
+ * This client is used when the endpoint supports privileged access and the session is configured to use privileged transfer type.
+ *
+ * @since 1.11.0
+ */
+public class LargeObjectClientVoid implements LargeObjectClient {
+    static final String ERROR_MESSAGE = "BLOB functionality is unavailable in this session."; //$NON-NLS-1$
+
+    @Override
+    public FutureResponse<LargeObjectInfo> upload(InputStream source) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<LargeObjectInfo> upload(Reader source) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<LargeObjectInfo> upload(Path source) throws IOException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<InputStream> openInputStream(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<Reader> openReader(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<LargeObjectCache> getLargeObjectCache(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+
+    @Override
+    public FutureResponse<Void> copyTo(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref, @Nonnull Path destination) throws BlobException {
+        throw new IllegalStateException(ERROR_MESSAGE);
+    }
+}

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
@@ -234,11 +234,11 @@ public class SessionImpl implements Session {
 
     private LargeObjectClient getLargeObjectClient(BlobTransferMedium blobTransferMedium) {
         if (blobTransferMedium == null) {
-            return null;
+            return new LargeObjectClientVoid();
         }
         switch (blobTransferMedium.getBlobTransferType()) {
         case DOES_NOT_USE:
-            return null;
+            return new LargeObjectClientVoid();
         case RELAY:
             var parameters = blobTransferMedium.getParameters();
             String sessionId = parameters.get("sessionId");


### PR DESCRIPTION
This PR fixes the “BLOB transfer not used / not set” behavior by ensuring the session/wire consistently treats such cases as “BLOB unavailable” rather than leaving the BLOB client unset or defaulting to privileged mode.

**Changes:**
- `SessionImpl` now returns a non-null `LargeObjectClient` (`LargeObjectClientVoid`) when BLOB transfer is disabled or unspecified, instead of returning `null`.
- Introduces `LargeObjectClientVoid`, which fails fast for all BLOB operations with a clear `IllegalStateException`.
- `WireImpl` now maps `BLOBTRANSFER_NOT_SET` handshake results to `BlobTransferType.DOES_NOT_USE`.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401