### PR TITLE
enable handling of large objects that exceed the buffer size

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -251,7 +251,6 @@ public class BlobRelayStreaming implements Closeable {
                 // Handle the completion
                 try {
                     bufferedOutputStream.close();
-                    outputStream.close();
                 } catch (IOException e) {
                     // Handle the exception
                 }

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -251,6 +251,7 @@ public class BlobRelayStreaming implements Closeable {
                 // Handle the completion
                 try {
                     bufferedOutputStream.close();
+                    outputStream.close();
                 } catch (IOException e) {
                     // Handle the exception
                 }

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -165,8 +165,8 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                 int len;
                 while ((len = reader.read(buffer)) != -1) {
                     writer.write(buffer, 0, len);
-                    writer.flush();
                 }
+                writer.flush();
             } catch (IOException e) {
                 LOG.error("Error while converting Reader to InputStream", e);
             } finally {
@@ -205,13 +205,25 @@ public class LargeObjectClientRelay implements LargeObjectClient {
         }
 
         public void setException(Exception e) {
-            exceptionRef.set(e);
+            exceptionRef.compareAndSet(null, e);
         }
 
         @Override
         public int read() throws IOException {
             checkException();
             return super.read();
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            checkException();
+            return super.read(b);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            checkException();
+            return super.read(b, off, len);
         }
 
         private void checkException() throws IOException {
@@ -245,7 +257,7 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                 var request = newGetStreamingRequest(contextId, ref);
                 try {
                     openBlobRelayStreaming();
-                    new Thread(() -> {
+                    Thread thread = new Thread(() -> {
                         try {
                             blobRelayStreaming.get(request, pipedOutputStream, timeout, unit);
                         } catch (IOException e) {
@@ -260,7 +272,9 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                                 pipedInputStream.setException(e);
                             }
                         }
-                    }).start();
+                    }, "tsubakuro-blob-relay-get");
+                    thread.setDaemon(true);
+                    thread.start();
                     return pipedInputStream;
                 } finally {
                     done = true;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.Optional;
@@ -164,9 +165,16 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                 int len;
                 while ((len = reader.read(buffer)) != -1) {
                     writer.write(buffer, 0, len);
+                    writer.flush();
                 }
             } catch (IOException e) {
                 LOG.error("Error while converting Reader to InputStream", e);
+            } finally {
+                try {
+                    pos.close();
+                } catch (IOException e) {
+                    LOG.error("Error while closing PipedOutputStream", e);
+                }
             }
         }).start();
 
@@ -187,17 +195,72 @@ public class LargeObjectClientRelay implements LargeObjectClient {
         }
     }
 
+    private static class CustomPipedInputStream extends PipedInputStream {
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>(null);
+        private final PipedOutputStream pipedOutputStream;
+
+        CustomPipedInputStream(PipedOutputStream pipedOutputStream) throws IOException {
+            super(pipedOutputStream);
+            this.pipedOutputStream = pipedOutputStream;
+        }
+
+        public void setException(Exception e) {
+            exceptionRef.set(e);
+        }
+
+        @Override
+        public int read() throws IOException {
+            checkException();
+            return super.read();
+        }
+
+        private void checkException() throws IOException {
+            Exception e = exceptionRef.get();
+            if (e != null) {
+                if (e instanceof IOException) {
+                    throw (IOException) e;
+                } else if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Thread was interrupted", e);
+                } else {
+                    throw new IOException("Unexpected exception occurred", e);
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            pipedOutputStream.close();
+        }
+    }
+
     @Override
     public FutureResponse<InputStream> openInputStream(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
         return new FutureResponseImpl<InputStream>() {
             @Override
             public InputStream get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
                 final PipedOutputStream pipedOutputStream = new PipedOutputStream();
-                final PipedInputStream pipedInputStream = new PipedInputStream(pipedOutputStream);
+                final CustomPipedInputStream pipedInputStream = new CustomPipedInputStream(pipedOutputStream);
                 var request = newGetStreamingRequest(contextId, ref);
                 try {
                     openBlobRelayStreaming();
-                    blobRelayStreaming.get(request, pipedOutputStream, timeout, unit);
+                    new Thread(() -> {
+                        try {
+                            blobRelayStreaming.get(request, pipedOutputStream, timeout, unit);
+                        } catch (IOException e) {
+                            pipedInputStream.setException(e);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            pipedInputStream.setException(e);
+                        } finally {
+                            try {
+                                pipedOutputStream.close();
+                            } catch (IOException e) {
+                                pipedInputStream.setException(e);
+                            }
+                        }
+                    }).start();
                     return pipedInputStream;
                 } finally {
                     done = true;

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 // import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -33,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.io.ByteArrayOutputStream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -215,6 +217,30 @@ class LargeObjectClientRelayTest {
         assertEquals(1, lobReference.getStorageId());
         assertEquals(12345, lobReference.getObjectId());
         assertEquals(678, lobReference.getTag());
+        assertFalse(server.hasRemaining());
+    }
+
+    @Test
+    void openInputStream_largeBlob() throws Exception {
+        byte[] largeData = new byte[4096];
+        for (int i = 0; i < largeData.length; i++) {
+            largeData[i] = (byte) ('a' + (i % 26));
+        }
+
+        server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
+                                .setChunk(com.google.protobuf.ByteString.copyFrom(largeData))
+                                .build());
+        server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
+                                .setMetadata(Streaming.GetStreamingResponse.Metadata.newBuilder()
+                                    .setBlobSize(largeData.length))
+                                .build());
+
+        assertTimeoutPreemptively(Duration.ofSeconds(3), () -> {
+            var inputStream = client.openInputStream(contextId, lobReference).await();
+            assertNotNull(inputStream);
+            var obtainedData = inputStream.readAllBytes();
+            assertArrayEquals(largeData, obtainedData);
+        });
         assertFalse(server.hasRemaining());
     }
 


### PR DESCRIPTION
This PR addresses issue #1401 by changing LOB download/upload streaming behavior so that objects larger than the internal pipe buffer can be handled without deadlocking, primarily by moving relay `get()` execution onto a background thread and improving stream closure.

**Changes:**
- Stream `LargeObjectClientRelay.openInputStream()` results via a background thread writing into a piped stream to avoid buffer-size deadlocks.
- Add a `CustomPipedInputStream` to propagate background-thread exceptions to the consumer.
- Ensure underlying output streams are closed on gRPC completion in `BlobRelayStreaming`.