### PR TITLE
fix error handling in LargeObjectClientRelay.java

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -292,7 +292,7 @@ public class BlobRelayStreaming implements Closeable {
                 Thread.currentThread().interrupt();
                 throw (InterruptedException) cause;
             }
-            throw new IOException("Failed to retrieve blob data, as " + cause.getMessage(), cause);
+            throw new IOException("Failed to retrieve blob data", cause);
         }
 
         // check the metadata and total bytes
@@ -302,7 +302,7 @@ public class BlobRelayStreaming implements Closeable {
         }
         if (metadata.getBlobSizeOptCase() == Streaming.GetStreamingResponse.Metadata.BlobSizeOptCase.BLOB_SIZE) {
             if (totalBytes.get() != metadata.getBlobSize()) {
-                throw new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " byte does not match received size " + totalBytes.get() + " byte");
+                throw new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " bytes does not match received size " + totalBytes.get() + " bytes");
             }
         }
     }

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -174,7 +174,7 @@ public class BlobRelayStreaming implements Closeable {
                 Thread.currentThread().interrupt();
                 throw (InterruptedException) cause;
             }
-            throw new IOException("Failed to retrieve blob data", cause);
+            throw new IOException("Failed to send blob data", cause);
         }
         return reference.get();
     }
@@ -292,17 +292,17 @@ public class BlobRelayStreaming implements Closeable {
                 Thread.currentThread().interrupt();
                 throw (InterruptedException) cause;
             }
-            throw new IOException("Failed to retrieve blob data", cause);
+            throw new IOException("Failed to retrieve blob data, as " + cause.getMessage(), cause);
         }
 
         // check the metadata and total bytes
         var metadata = reference.get();
         if (metadata == null) {
-            throw new IOException("Failed to retrieve blob data: metadata is missing");
+            throw new IOException("Failed to retrieve blob data, as metadata is missing");
         }
         if (metadata.getBlobSizeOptCase() == Streaming.GetStreamingResponse.Metadata.BlobSizeOptCase.BLOB_SIZE) {
             if (totalBytes.get() != metadata.getBlobSize()) {
-                throw new IOException("Failed to retrieve blob data: expected size " + metadata.getBlobSize() + " bytes, but received " + totalBytes.get() + " bytes");
+                throw new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " byte does not match received size " + totalBytes.get() + " byte");
             }
         }
     }

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -215,20 +215,33 @@ public class LargeObjectClientRelay implements LargeObjectClient {
 
         @Override
         public int read() throws IOException {
+            int rv = super.read();
             checkException();
-            return super.read();
+            return rv;
         }
 
         @Override
         public int read(byte[] b) throws IOException {
+            int rv = super.read(b);
             checkException();
-            return super.read(b);
+            return rv;
         }
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
+            int rv = super.read(b, off, len);
             checkException();
-            return super.read(b, off, len);
+            return rv;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                checkException();
+            } finally {
+                super.close();
+                pipedOutputStream.close();
+            }
         }
 
         private void checkException() throws IOException {
@@ -243,12 +256,6 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                     throw new IOException("Unexpected exception occurred", e);
                 }
             }
-        }
-
-        @Override
-        public void close() throws IOException {
-            super.close();
-            pipedOutputStream.close();
         }
     }
 


### PR DESCRIPTION
Tightens error-handling and error-message wording around the BLOB relay download/upload paths. In `LargeObjectClientRelay`, the `CustomPipedInputStream` now reads first and checks the deferred exception afterwards, and overrides `close()` so that a pending exception is surfaced on stream close. In `BlobRelayStreaming`, the `put()` failure message is corrected (it previously said "retrieve") and the `get()` failure messages are reworded to include the underlying cause text and to use a "..., as ..." style.

**Changes:**
- Reorder `read()` overrides in `CustomPipedInputStream` and add a `close()` override that calls `checkException()` before closing.
- Fix the `put()` wrap-up error message from "Failed to retrieve blob data" to "Failed to send blob data".
- Reword the `get()` error messages (gRPC failure, missing metadata, size mismatch).

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401