### PR TITLE
address the condition's abnormal behavior

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -221,7 +221,7 @@ public class BlobRelayStreaming implements Closeable {
                             bufferedOutputStream.flush();
                         } catch (IOException e) {
                             // Handle the exception
-                            onError(e);
+                            error.set(e);
                         }
                         break;
                     case METADATA:

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -205,8 +205,8 @@ public class BlobRelayStreaming implements Closeable {
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final AtomicLong totalBytes = new AtomicLong(0);
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Lock lock = new ReentrantLock();
-        Condition condition = lock.newCondition();
+        final Lock lock = new ReentrantLock();
+        final Condition condition = lock.newCondition();
 
         final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
         final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
@@ -221,6 +221,7 @@ public class BlobRelayStreaming implements Closeable {
                             bufferedOutputStream.flush();
                         } catch (IOException e) {
                             // Handle the exception
+                            onError(e);
                         }
                         break;
                     case METADATA:
@@ -252,6 +253,7 @@ public class BlobRelayStreaming implements Closeable {
                     bufferedOutputStream.close();
                 } catch (IOException e) {
                     // Handle the exception
+                    error.set(e);
                 }
                 lock.lock();
                 try {
@@ -273,7 +275,11 @@ public class BlobRelayStreaming implements Closeable {
         try {
             while (!completed.get()) {
                 try {
-                    condition.await();
+                    if (condition.await(10, TimeUnit.MILLISECONDS)) { // Wait for 10 millisecond
+                        if (completed.get()) {
+                            break;
+                        }
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw e;


### PR DESCRIPTION
Workaround for a CI hang observed in `BlobRelayStreaming#get(...)`. The untimed `condition.await()` in the response wait loop is replaced with a 10 ms polled wait, and the IOException paths in `onNext` (chunk write failure) and `onCompleted` (close failure) now propagate the error instead of being silently swallowed. The two local fields are also made `final`.

**Changes:**
- Replace `condition.await()` with `condition.await(10, TimeUnit.MILLISECONDS)` polling loop, with an inner break on `completed`.
- Forward a chunk-write `IOException` to `error.set(e);` from inside `onNext`.
- Record the close-failure `IOException` from `onCompleted` into the `error` reference.