### PR TITLE
revise gRPC client

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -23,11 +23,8 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
@@ -96,9 +93,7 @@ public class BlobRelayStreaming implements Closeable {
     public BlobRelayCommon.BlobReference put(Streaming.PutStreamingRequest.Metadata meta, InputStream input, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
         final AtomicReference<BlobRelayCommon.BlobReference> reference = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
-        final AtomicBoolean completed = new AtomicBoolean(false);
-        final Lock lock = new ReentrantLock();
-        final Condition condition = lock.newCondition();
+        final AtomicReference<CountDownLatch> countDownLatch = new AtomicReference<>(new CountDownLatch(1));
 
         final class PutResponseObserver implements StreamObserver<Streaming.PutStreamingResponse> {
             @Override
@@ -108,25 +103,13 @@ public class BlobRelayStreaming implements Closeable {
 
             @Override
             public void onError(Throwable t) {
-                lock.lock();
-                try {
-                    error.set(t);
-                    completed.set(true);
-                    condition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
+                error.set(t);
+                countDownLatch.get().countDown();
             }
 
             @Override
             public void onCompleted() {
-                lock.lock();
-                try {
-                    completed.set(true);
-                    condition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
+                countDownLatch.get().countDown();
             }
         }
 
@@ -154,31 +137,8 @@ public class BlobRelayStreaming implements Closeable {
         // Mark the end of requests
         requestObserver.onCompleted();
 
-        lock.lock();
-        try {
-            while (!completed.get()) {
-                try {
-                    condition.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw e;
-                }
-            }
-        } finally {
-            lock.unlock();
-        }
-        Throwable cause = error.get();
-        if (cause != null) {
-            close();
-            if (cause instanceof IOException) {
-                throw (IOException) cause;
-            }
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw (InterruptedException) cause;
-            }
-            throw new IOException("Failed to send blob data", cause);
-        }
+        countDownLatch.get().await();
+        checkException(error.get());
         return reference.get();
     }
 
@@ -258,7 +218,7 @@ public class BlobRelayStreaming implements Closeable {
      * @param timeout the timeout in milliseconds for the gRPC call
      * @param timeUnit the TimeUnit for the timeout
      * @return an InputStream to read the Blob data
-     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
     public InputStream get(Streaming.GetStreamingRequest request, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
@@ -269,7 +229,7 @@ public class BlobRelayStreaming implements Closeable {
      * Receives Blob data from the gRPC server.
      * @param request the request containing the reference to the Blob data to retrieve
      * @return an InputStream to read the Blob data
-     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
     public InputStream get(Streaming.GetStreamingRequest request) throws IOException, InterruptedException {
@@ -282,7 +242,7 @@ public class BlobRelayStreaming implements Closeable {
      * @param path the Path to write the Blob data to
      * @param timeout the timeout in milliseconds for the gRPC call
      * @param timeUnit the TimeUnit for the timeout
-     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
     public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
@@ -293,7 +253,7 @@ public class BlobRelayStreaming implements Closeable {
      * Receives Blob data from the gRPC server.
      * @param request the request containing the reference to the Blob data to retrieve
      * @param path the Path to write the Blob data to
-     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
     public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path) throws IOException, InterruptedException {
@@ -301,10 +261,10 @@ public class BlobRelayStreaming implements Closeable {
     }
 
     private InputStream getInternal(@Nonnull Streaming.GetStreamingRequest request, @Nullable Path path, long timeout, @Nullable TimeUnit timeUnit) throws IOException, InterruptedException {
-        final AtomicBoolean completed = new AtomicBoolean(false);
         final boolean writeToFile = (path != null);
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final AtomicReference<CustomPipedInputStream> inputStream = new AtomicReference<>(null);
+        final AtomicReference<CountDownLatch> countDownLatch = new AtomicReference<>(writeToFile ? new CountDownLatch(1) : null);
 
         final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
             final OutputStream outputStream;
@@ -351,12 +311,28 @@ public class BlobRelayStreaming implements Closeable {
             @Override
             public void onError(Throwable t) {
                 // Handle the error
-                setError(t);
+                try {
+                    setError(t);
+                } finally {
+                    if (writeToFile) {
+                        try {
+                            outputStream.close();
+                        } catch (IOException e) {
+                            // Handle the exception
+                            error.set(e);
+                        }
+                    }
+                    if (writeToFile) {
+                        countDownLatch.get().countDown();
+                    }
+                }
             }
 
             @Override
             public void onCompleted() {
-                completed.set(true);
+                if (writeToFile) {
+                    countDownLatch.get().countDown();
+                }
                 // Handle the completion
                 try {
                     outputStream.close();
@@ -393,15 +369,7 @@ public class BlobRelayStreaming implements Closeable {
         }
 
         if (writeToFile) {
-            // Wait for the response to complete
-            while (!completed.get() && error.get() == null) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw e;
-                }
-            }
+            countDownLatch.get().await();
             checkException(error.get());
             return null;
         } else {

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -15,13 +15,15 @@
  */
 package com.tsurugidb.tsubakuro.relay.client;
 
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -29,6 +31,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
@@ -191,124 +194,60 @@ public class BlobRelayStreaming implements Closeable {
         return put(meta, input, 0, null);
     }
 
-    /**
-     * Receives Blob data from the gRPC server.
-     * @param request the request containing the reference to the Blob data to retrieve
-     * @param outputStream the OutputStream to write the retrieved Blob data to
-     * @param timeout the timeout in milliseconds for the gRPC call
-     * @param timeUnit the TimeUnit for the timeout
-     * @throws IOException if an I/O error occurs while writing to the OutputStream
-     * @throws InterruptedException if the thread is interrupted while waiting for the response
-     */
-    public void get(Streaming.GetStreamingRequest request, OutputStream outputStream, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
-        final AtomicReference<Streaming.GetStreamingResponse.Metadata> reference = new AtomicReference<>();
-        final AtomicReference<Throwable> error = new AtomicReference<>();
-        final AtomicLong totalBytes = new AtomicLong(0);
-        final AtomicBoolean completed = new AtomicBoolean(false);
-        final Lock lock = new ReentrantLock();
-        final Condition condition = lock.newCondition();
+    private static class CustomPipedInputStream extends PipedInputStream {
+        AtomicReference<Throwable> exceptionRef = new AtomicReference<>(null);
+        private final PipedOutputStream pipedOutputStream;
 
-        final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
-        final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
-            @Override
-            public void onNext(Streaming.GetStreamingResponse response) {
-                switch (response.getPayloadCase()) {
-                    case CHUNK:
-                        try {
-                            var chunk = response.getChunk();
-                            totalBytes.addAndGet(chunk.size());
-                            bufferedOutputStream.write(chunk.toByteArray());
-                            bufferedOutputStream.flush();
-                        } catch (IOException e) {
-                            // Handle the exception
-                            error.set(e);
-                        }
-                        break;
-                    case METADATA:
-                        reference.set(response.getMetadata());
-                        break;
-                    case PAYLOAD_NOT_SET:
-                        // Handle the case where no payload is set
-                        break;
-                }
-            }
+        CustomPipedInputStream(PipedOutputStream pipedOutputStream, int pipeSize) throws IOException {
+            super(pipedOutputStream, pipeSize);
+            this.pipedOutputStream = pipedOutputStream;
+        }
 
-            @Override
-            public void onError(Throwable t) {
-                // Handle the error
-                lock.lock();
-                try {
-                    error.set(t);
-                    completed.set(true);
-                    condition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
-            }
+        public void setException(Throwable e) {
+            exceptionRef.compareAndSet(null, e);
+        }
 
-            @Override
-            public void onCompleted() {
-                // Handle the completion
-                try {
-                    bufferedOutputStream.close();
-                } catch (IOException e) {
-                    // Handle the exception
-                    error.set(e);
-                }
-                lock.lock();
-                try {
-                    completed.set(true);
-                    condition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
+        @Override
+        public int read() throws IOException {
+            int rv = super.read();
+            checkException();
+            return rv;
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            int rv = super.read(b);
+            checkException();
+            return rv;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int rv = super.read(b, off, len);
+            checkException();
+            return rv;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                checkException();
+            } finally {
+                super.close();
+                pipedOutputStream.close();
             }
         }
 
-        if (timeout > 0 && timeUnit != null) {
-            stub.withDeadlineAfter(timeout, timeUnit).get(request, new GetResponseObserver());
-        } else {
-            stub.get(request, new GetResponseObserver());
-        }
-
-        lock.lock();
-        try {
-            while (!completed.get()) {
-                try {
-                    if (condition.await(10, TimeUnit.MILLISECONDS)) { // Wait for 10 millisecond
-                        if (completed.get()) {
-                            break;
-                        }
-                    }
-                } catch (InterruptedException e) {
+        private void checkException() throws IOException {
+            Throwable e = exceptionRef.get();
+            if (e != null) {
+                if (e instanceof IOException) {
+                    throw (IOException) e;
+                } else if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
-                    throw e;
+                    throw new IOException("Thread was interrupted", e);
                 }
-            }
-        } finally {
-            lock.unlock();
-        }
-        Throwable cause = error.get();
-        if (cause != null) {
-            close();
-            if (cause instanceof IOException) {
-                throw (IOException) cause;
-            }
-            if (cause instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw (InterruptedException) cause;
-            }
-            throw new IOException("Failed to retrieve blob data", cause);
-        }
-
-        // check the metadata and total bytes
-        var metadata = reference.get();
-        if (metadata == null) {
-            throw new IOException("Failed to retrieve blob data, as metadata is missing");
-        }
-        if (metadata.getBlobSizeOptCase() == Streaming.GetStreamingResponse.Metadata.BlobSizeOptCase.BLOB_SIZE) {
-            if (totalBytes.get() != metadata.getBlobSize()) {
-                throw new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " bytes does not match received size " + totalBytes.get() + " bytes");
+                throw new IOException("Unexpected exception occurred", e);
             }
         }
     }
@@ -316,11 +255,168 @@ public class BlobRelayStreaming implements Closeable {
     /**
      * Receives Blob data from the gRPC server.
      * @param request the request containing the reference to the Blob data to retrieve
-     * @param outputStream the OutputStream to write the retrieved Blob data to
+     * @param timeout the timeout in milliseconds for the gRPC call
+     * @param timeUnit the TimeUnit for the timeout
+     * @return an InputStream to read the Blob data
      * @throws IOException if an I/O error occurs while writing to the OutputStream
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
-    public void get(Streaming.GetStreamingRequest request, OutputStream outputStream) throws IOException, InterruptedException {
-        get(request, outputStream, 0, null);
+    public InputStream get(Streaming.GetStreamingRequest request, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
+        return getInternal(request, null, timeout, timeUnit);
+    }
+
+    /**
+     * Receives Blob data from the gRPC server.
+     * @param request the request containing the reference to the Blob data to retrieve
+     * @return an InputStream to read the Blob data
+     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws InterruptedException if the thread is interrupted while waiting for the response
+     */
+    public InputStream get(Streaming.GetStreamingRequest request) throws IOException, InterruptedException {
+        return get(request, 0, null);
+    }
+
+    /**
+     * Receives Blob data from the gRPC server.
+     * @param request the request containing the reference to the Blob data to retrieve
+     * @param path the Path to write the Blob data to
+     * @param timeout the timeout in milliseconds for the gRPC call
+     * @param timeUnit the TimeUnit for the timeout
+     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws InterruptedException if the thread is interrupted while waiting for the response
+     */
+    public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
+        getInternal(request, path, timeout, timeUnit);
+    }
+
+    /**
+     * Receives Blob data from the gRPC server.
+     * @param request the request containing the reference to the Blob data to retrieve
+     * @param path the Path to write the Blob data to
+     * @throws IOException if an I/O error occurs while writing to the OutputStream
+     * @throws InterruptedException if the thread is interrupted while waiting for the response
+     */
+    public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path) throws IOException, InterruptedException {
+        get(request, path, 0, null);
+    }
+
+    private InputStream getInternal(@Nonnull Streaming.GetStreamingRequest request, @Nullable Path path, long timeout, @Nullable TimeUnit timeUnit) throws IOException, InterruptedException {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final boolean writeToFile = (path != null);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicReference<CustomPipedInputStream> inputStream = new AtomicReference<>(null);
+
+        final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
+            final OutputStream outputStream;
+
+            Streaming.GetStreamingResponse.Metadata metadata = null;
+            long totalBytes = 0;
+
+            GetResponseObserver(OutputStream outputStream) {
+                this.outputStream = outputStream;
+            }
+
+            @Override
+            public void onNext(Streaming.GetStreamingResponse response) {
+                switch (response.getPayloadCase()) {
+                    case CHUNK:
+                        try {
+                            var chunk = response.getChunk();
+                            totalBytes += chunk.size();
+                            outputStream.write(chunk.toByteArray());
+                            outputStream.flush();
+                        } catch (IOException e) {
+                            // Handle the exception
+                            setError(e);
+                        }
+                        break;
+                    case METADATA:
+                        metadata = response.getMetadata();
+                        break;
+                    case PAYLOAD_NOT_SET:
+                        // Handle the case where no payload is set
+                        break;
+                }
+            }
+            private void setError(Throwable e) {
+                 if (writeToFile) {
+                    error.set(e);
+                } else {
+                    if (inputStream.get() != null) {
+                        inputStream.get().setException(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // Handle the error
+                setError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                completed.set(true);
+                // Handle the completion
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    // Handle the exception
+                    setError(e);
+                }
+                // check the metadata and total bytes
+                if (metadata == null) {
+                    setError(new IOException("Failed to retrieve blob data, as metadata is missing"));
+                } else {
+                    if (metadata.getBlobSizeOptCase() == Streaming.GetStreamingResponse.Metadata.BlobSizeOptCase.BLOB_SIZE) {
+                        if (totalBytes != metadata.getBlobSize()) {
+                            setError(new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " bytes does not match received size " + totalBytes + " bytes"));
+                        }
+                    }
+                }
+            }
+        }
+
+        GetResponseObserver responseObserver;
+        if (writeToFile) {
+            responseObserver = new GetResponseObserver(new FileOutputStream(path.toFile()));
+        } else {
+            PipedOutputStream pipedOutputStream = new PipedOutputStream();
+            responseObserver = new GetResponseObserver(pipedOutputStream);
+            inputStream.set(new CustomPipedInputStream(pipedOutputStream, (int) chunkSize));
+        }
+
+        if (timeout > 0 && timeUnit != null) {
+            stub.withDeadlineAfter(timeout, timeUnit).get(request, responseObserver);
+        } else {
+            stub.get(request, responseObserver);
+        }
+
+        if (writeToFile) {
+            // Wait for the response to complete
+            while (!completed.get() && error.get() == null) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
+            }
+            checkException(error.get());
+            return null;
+        } else {
+            return inputStream.get();
+        }
+    }
+    private static void checkException(Throwable e) throws IOException {
+        if (e != null) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            } else if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Thread was interrupted", e);
+            }
+            throw new IOException("Unexpected exception occurred", e);
+        }
     }
 }

--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -108,16 +108,14 @@ class BlobRelayStreamingTest {
 
         // test get() method
         client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
-        var outputStream = new ByteArrayOutputStream();
-        client.get(Streaming.GetStreamingRequest.newBuilder()
+        var inputStream = client.get(Streaming.GetStreamingRequest.newBuilder()
                                                     .setTransactionId(789)
                                                     .setBlob(BlobRelayCommon.BlobReference.newBuilder()
                                                         .setStorageId(1)
                                                         .setObjectId(23)
                                                         .setTag(45))
-                                                .build(),
-                   outputStream);
-        var data = outputStream.toByteArray();
+                                                .build());
+        var data = inputStream.readAllBytes();
 
         // verify received data
         assertArrayEquals(buffer, data);

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -28,7 +28,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.Optional;
@@ -200,94 +199,14 @@ public class LargeObjectClientRelay implements LargeObjectClient {
         }
     }
 
-    private static class CustomPipedInputStream extends PipedInputStream {
-        AtomicReference<Exception> exceptionRef = new AtomicReference<>(null);
-        private final PipedOutputStream pipedOutputStream;
-
-        CustomPipedInputStream(PipedOutputStream pipedOutputStream, int pipeSize) throws IOException {
-            super(pipedOutputStream, pipeSize);
-            this.pipedOutputStream = pipedOutputStream;
-        }
-
-        public void setException(Exception e) {
-            exceptionRef.compareAndSet(null, e);
-        }
-
-        @Override
-        public int read() throws IOException {
-            int rv = super.read();
-            checkException();
-            return rv;
-        }
-
-        @Override
-        public int read(byte[] b) throws IOException {
-            int rv = super.read(b);
-            checkException();
-            return rv;
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            int rv = super.read(b, off, len);
-            checkException();
-            return rv;
-        }
-
-        @Override
-        public void close() throws IOException {
-            try {
-                checkException();
-            } finally {
-                super.close();
-                pipedOutputStream.close();
-            }
-        }
-
-        private void checkException() throws IOException {
-            Exception e = exceptionRef.get();
-            if (e != null) {
-                if (e instanceof IOException) {
-                    throw (IOException) e;
-                } else if (e instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                    throw new IOException("Thread was interrupted", e);
-                } else {
-                    throw new IOException("Unexpected exception occurred", e);
-                }
-            }
-        }
-    }
-
     @Override
     public FutureResponse<InputStream> openInputStream(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
         return new FutureResponseImpl<InputStream>() {
             @Override
             public InputStream get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
-                final PipedOutputStream pipedOutputStream = new PipedOutputStream();
-                final CustomPipedInputStream pipedInputStream = new CustomPipedInputStream(pipedOutputStream, (int) chunkSize);
-                var request = newGetStreamingRequest(contextId, ref);
                 try {
                     openBlobRelayStreaming();
-                    Thread thread = new Thread(() -> {
-                        try {
-                            blobRelayStreaming.get(request, pipedOutputStream, timeout, unit);
-                        } catch (IOException e) {
-                            pipedInputStream.setException(e);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            pipedInputStream.setException(e);
-                        } finally {
-                            try {
-                                pipedOutputStream.close();
-                            } catch (IOException e) {
-                                pipedInputStream.setException(e);
-                            }
-                        }
-                    }, "tsubakuro-blob-relay-get");
-                    thread.setDaemon(true);
-                    thread.start();
-                    return pipedInputStream;
+                    return blobRelayStreaming.get(newGetStreamingRequest(contextId, ref),  timeout, unit);
                 } finally {
                     done = true;
                 }
@@ -343,7 +262,7 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                 var request = newGetStreamingRequest(contextId, ref);
                 try (FileOutputStream fileOutputStream = new FileOutputStream(destination.toFile())) {
                     openBlobRelayStreaming();
-                    blobRelayStreaming.get(request, fileOutputStream, timeout, unit);
+                    blobRelayStreaming.get(request, destination, timeout, unit);
                     return null;
                 } finally {
                     done = true;


### PR DESCRIPTION
Refactors the gRPC blob-download client so that `BlobRelayStreaming.get(...)` produces an `InputStream` (or writes directly to a `Path`) instead of taking a caller-supplied `OutputStream`, and pulls the `CustomPipedInputStream` plumbing down out of `LargeObjectClientRelay`. `LargeObjectClientRelay.openInputStream()` now just returns the relay client's stream, and `copyTo()` delegates to the new path-based overload.

**Changes:**
- Move `CustomPipedInputStream` and the spawn-a-thread/pipe wiring from `LargeObjectClientRelay` into `BlobRelayStreaming`.
- Replace `BlobRelayStreaming.get(request, OutputStream, ...)` with `get(request, ...) -> InputStream` and `get(request, Path, ...)` overloads, and rework completion handling (drop `Lock`/`Condition`, switch to `Thread.sleep` polling for the file path).
- Update `BlobRelayStreamingTest.get()` to consume the returned `InputStream`.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401