### PR TITLE
alter UnsupportedOperationException to BlobException

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientPrivileged.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientPrivileged.java
@@ -111,12 +111,12 @@ public class LargeObjectClientPrivileged implements LargeObjectClient {
 
     @Override
     public FutureResponse<LargeObjectInfo> upload(InputStream source) throws BlobException {
-        throw new UnsupportedOperationException("Privileged upload from InputStream is not supported.");
+        throw new BlobException("Privileged upload from InputStream is not supported.");
     }
 
     @Override
     public FutureResponse<LargeObjectInfo> upload(Reader source) throws BlobException {
-        throw new UnsupportedOperationException("Privileged upload from Reader is not supported.");
+        throw new BlobException("Privileged upload from Reader is not supported.");
     }
 
     @Override


### PR DESCRIPTION
This PR updates the privileged large-object client to throw the domain-specific `BlobException` (instead of `UnsupportedOperationException`) for upload operations that are not supported in privileged mode, aligning the behavior with the `LargeObjectClient` contract that privileged-mode upload APIs may fail via `BlobException`.

**Changes:**
- Replace `UnsupportedOperationException` with `BlobException` in privileged-mode `upload(InputStream)` and `upload(Reader)`.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401#issuecomment-4550673653
