### PR TITLE
implement gRPC timeout

### DIFF
--- a/modules/relay/build.gradle
+++ b/modules/relay/build.gradle
@@ -10,6 +10,8 @@ def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 dependencies {
+    api project(':tsubakuro-common')
+
     api "com.google.protobuf:protobuf-java:${protobufVersion}"
     api "io.grpc:grpc-services:${grpcVersion}"
 

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -309,7 +309,7 @@ public class BlobRelayStreaming implements Closeable {
                         break;
                 }
             }
-            synchronized private void setError(Throwable e) {
+            private synchronized void setError(Throwable e) {
                 var err = error.get();
                 if (err != null) {
                     err.addSuppressed(e);

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -114,7 +114,7 @@ public class BlobRelayStreaming implements Closeable {
                         isDeadlineExceeded = true;
                     }
                 }
-                error.set(isDeadlineExceeded ? new ResponseTimeoutException(t.getMessage()) : t);
+                error.set(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
                 countDownLatch.get().countDown();
             }
 
@@ -309,12 +309,18 @@ public class BlobRelayStreaming implements Closeable {
                         break;
                 }
             }
-            private void setError(Throwable e) {
-                 if (writeToFile) {
-                    error.set(e);
+            synchronized private void setError(Throwable e) {
+                var err = error.get();
+                if (err != null) {
+                    err.addSuppressed(e);
+                } else {
+                    err = e;
+                }
+                if (writeToFile) {
+                    error.set(err);
                 } else {
                     if (inputStream.get() != null) {
-                        inputStream.get().setException(e);
+                        inputStream.get().setException(err);
                     }
                 }
             }
@@ -330,7 +336,7 @@ public class BlobRelayStreaming implements Closeable {
                             isDeadlineExceeded = true;
                         }
                     }
-                    setError(isDeadlineExceeded ? new ResponseTimeoutException(t.getMessage()) : t);
+                    setError(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
                 } finally {
                     try {
                         outputStream.close();

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -35,10 +35,13 @@ import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.StreamObserver;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 import com.tsurugidb.blob_relay.proto.BlobRelayStreamingGrpc;
 import com.tsurugidb.blob_relay.proto.BlobRelayCommon;
 import com.tsurugidb.blob_relay.proto.Streaming;
+import com.tsurugidb.tsubakuro.exception.ResponseTimeoutException;
 
 /**
  * BlobRelayStreaming is a class that provides methods for streaming Blob data using gRPC.
@@ -103,7 +106,15 @@ public class BlobRelayStreaming implements Closeable {
 
             @Override
             public void onError(Throwable t) {
-                error.set(t);
+                // Handle the error
+                boolean isDeadlineExceeded = false;
+                if (t instanceof StatusRuntimeException) {
+                    StatusRuntimeException statusEx = (StatusRuntimeException) t;
+                    if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                        isDeadlineExceeded = true;
+                    }
+                }
+                error.set(isDeadlineExceeded ? new ResponseTimeoutException(t.getMessage()) : t);
                 countDownLatch.get().countDown();
             }
 
@@ -312,15 +323,20 @@ public class BlobRelayStreaming implements Closeable {
             public void onError(Throwable t) {
                 // Handle the error
                 try {
-                    setError(t);
-                } finally {
-                    if (writeToFile) {
-                        try {
-                            outputStream.close();
-                        } catch (IOException e) {
-                            // Handle the exception
-                            error.set(e);
+                    boolean isDeadlineExceeded = false;
+                    if (t instanceof StatusRuntimeException) {
+                        StatusRuntimeException statusEx = (StatusRuntimeException) t;
+                        if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                            isDeadlineExceeded = true;
                         }
+                    }
+                    setError(isDeadlineExceeded ? new ResponseTimeoutException(t.getMessage()) : t);
+                } finally {
+                    try {
+                        outputStream.close();
+                    } catch (IOException e) {
+                        // Handle the exception
+                        setError(e);
                     }
                     if (writeToFile) {
                         countDownLatch.get().countDown();

--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -21,19 +21,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Path;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tsurugidb.blob_relay.proto.BlobRelayStreamingGrpc;
 import com.tsurugidb.blob_relay.proto.BlobRelayCommon;
 import com.tsurugidb.blob_relay.proto.Streaming;
+import com.tsurugidb.tsubakuro.exception.ResponseTimeoutException;
 import com.tsurugidb.tsubakuro.relay.server.BlobRelayStreamingServer;
 
 class BlobRelayStreamingTest {
@@ -61,6 +66,9 @@ class BlobRelayStreamingTest {
     void teardown() throws IOException, InterruptedException {
         server.stop();
         server.blockUntilShutdown();
+        if (client != null) {
+            client.close();
+        }
     }
 
     @Test
@@ -88,6 +96,24 @@ class BlobRelayStreamingTest {
         assertNotNull(result);
         assertEquals(response.getBlob(), result);
         assertArrayEquals(data, server.receivedData());
+    }
+
+    @Test
+    void pugTimeout() throws Exception {
+        server.injectFault(BlobRelayStreamingServer.FaultType.NoResponse);
+
+        // test put() method
+        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
+        var data = new byte[TEST_DATA_SIZE];
+        new Random().nextBytes(data);
+
+        Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
+            var result = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
+                                                                                .setSessionId(128)
+                                                                          .build(),
+                                    new ByteArrayInputStream(data),
+                                    1, TimeUnit.SECONDS);
+        });
     }
 
     @Test
@@ -119,5 +145,47 @@ class BlobRelayStreamingTest {
 
         // verify received data
         assertArrayEquals(buffer, data);
+    }
+
+    @Test
+    void getTimeout() throws Exception {
+        server.injectFault(BlobRelayStreamingServer.FaultType.NoResponse);
+
+        // test get() method
+        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
+
+        var inputStream = client.get(Streaming.GetStreamingRequest.newBuilder()
+                                                .setTransactionId(789)
+                                                .setBlob(BlobRelayCommon.BlobReference.newBuilder()
+                                                    .setStorageId(1)
+                                                    .setObjectId(23)
+                                                    .setTag(45))
+                                            .build(),
+                                            1, TimeUnit.SECONDS);
+        Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
+            inputStream.readAllBytes();
+        });
+    }
+
+    @Test
+    void getTimeoutWithPath(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("blog");
+
+        server.injectFault(BlobRelayStreamingServer.FaultType.NoResponse);
+
+        // test get() method
+        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
+
+        Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
+            client.get(Streaming.GetStreamingRequest.newBuilder()
+                                    .setTransactionId(789)
+                                    .setBlob(BlobRelayCommon.BlobReference.newBuilder()
+                                        .setStorageId(1)
+                                        .setObjectId(23)
+                                        .setTag(45))
+                                .build(),
+                                file,
+                                1, TimeUnit.SECONDS);
+        });
     }
 }

--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -99,7 +99,7 @@ class BlobRelayStreamingTest {
     }
 
     @Test
-    void pugTimeout() throws Exception {
+    void putTimeout() throws Exception {
         server.injectFault(BlobRelayStreamingServer.FaultType.NoResponse);
 
         // test put() method
@@ -107,12 +107,12 @@ class BlobRelayStreamingTest {
         var data = new byte[TEST_DATA_SIZE];
         new Random().nextBytes(data);
 
-        Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
-            var result = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
-                                                                                .setSessionId(128)
-                                                                          .build(),
-                                    new ByteArrayInputStream(data),
-                                    1, TimeUnit.SECONDS);
+        assertThrows(ResponseTimeoutException.class, () -> {
+            client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
+                                                                .setSessionId(128)
+                                                             .build(),
+                       new ByteArrayInputStream(data),
+                       1, TimeUnit.SECONDS);
         });
     }
 
@@ -176,7 +176,7 @@ class BlobRelayStreamingTest {
         // test get() method
         client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
 
-        Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
+        assertThrows(ResponseTimeoutException.class, () -> {
             client.get(Streaming.GetStreamingRequest.newBuilder()
                                     .setTransactionId(789)
                                     .setBlob(BlobRelayCommon.BlobReference.newBuilder()

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -48,7 +48,7 @@ public class BlobRelayStreamingServer {
     private final BlobRelayImpl blobRelayImpl = new BlobRelayImpl();
     private Server server;
     private int port;
-    private FaultType injectedFault;
+    private volatile FaultType injectedFault = FaultType.NoFault;
 
     public void start() throws IOException {
         ExecutorService executor = Executors.newFixedThreadPool(2);

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -48,6 +48,7 @@ public class BlobRelayStreamingServer {
     private final BlobRelayImpl blobRelayImpl = new BlobRelayImpl();
     private Server server;
     private int port;
+    private FaultType injectedFault;
 
     public void start() throws IOException {
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -98,7 +99,16 @@ public class BlobRelayStreamingServer {
         }
     }
 
-    static class BlobRelayImpl extends BlobRelayStreamingGrpc.BlobRelayStreamingImplBase {
+    public enum FaultType {
+        NoFault,
+        NoResponse,
+    }
+
+    public void injectFault(FaultType faultType) {
+        this.injectedFault = faultType;
+    }
+
+    class BlobRelayImpl extends BlobRelayStreamingGrpc.BlobRelayStreamingImplBase {
         private final ConcurrentLinkedQueue<Streaming.PutStreamingResponse> putResponses = new ConcurrentLinkedQueue<>();
         private final ConcurrentLinkedQueue<Streaming.GetStreamingResponse> getResponses = new ConcurrentLinkedQueue<>();
         private final AtomicLong receivedSize = new AtomicLong(0);
@@ -110,6 +120,24 @@ public class BlobRelayStreamingServer {
 
         @Override
         public StreamObserver<Streaming.PutStreamingRequest> put(StreamObserver<Streaming.PutStreamingResponse> responseObserver) {
+            if (injectedFault == FaultType.NoResponse) {
+                return new StreamObserver<Streaming.PutStreamingRequest>() {
+                    @Override
+                    public void onNext(Streaming.PutStreamingRequest request) {
+                        // Do nothing
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        // Do nothing
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        // Do nothing
+                    }
+                };
+            }
             return new StreamObserver<Streaming.PutStreamingRequest>() {
                 @Override
                 public void onNext(Streaming.PutStreamingRequest request) {
@@ -172,6 +200,9 @@ public class BlobRelayStreamingServer {
 
         @Override
         public void get(Streaming.GetStreamingRequest request, StreamObserver<Streaming.GetStreamingResponse> responseObserver) {
+            if (injectedFault == FaultType.NoResponse) {
+                return;
+            }
             blobReference = request.getBlob();
             while (!getResponses.isEmpty()) {
                 var response = getResponses.poll();


### PR DESCRIPTION
Implements client-side gRPC deadlines for Blob Relay streaming operations and standardizes timeout handling by surfacing `DEADLINE_EXCEEDED` as `ResponseTimeoutException`, with new tests that simulate “no response” server behavior (ref. project-tsurugi/tsurugi-issues#1401).

**Changes:**
- Translate gRPC `DEADLINE_EXCEEDED` errors into `ResponseTimeoutException` in `BlobRelayStreaming` put/get flows.
- Extend the test fixture server to simulate “no response” behavior and add timeout-focused unit tests.
- Add `tsubakuro-common` dependency to the relay module to provide `ResponseTimeoutException`.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401