### PR TITLE
fix the behavior of FutureResponse regarding gRPC calls

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -240,7 +240,7 @@ public class BlobRelayStreaming implements Closeable {
 
         private void waitforData() throws IOException {
             synchronized (this) {
-                while (available() < 1 && !pipedOutputStreamIsClosed.get()) {
+                while (available() < 1 && !pipedOutputStreamIsClosed.get() && exceptionRef.get() == null) {
                     try {
                         if (timeout > 0 && timeUnit != null) {
                             long timeoutMillis = timeUnit.toMillis(timeout);
@@ -337,6 +337,7 @@ public class BlobRelayStreaming implements Closeable {
                     err = e;
                 }
                 pipedInputStream.setException(err);
+                pipedInputStream.notifyDataAvailable(false);
             }
 
             @Override

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -21,14 +21,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
@@ -42,11 +46,15 @@ import com.tsurugidb.blob_relay.proto.BlobRelayStreamingGrpc;
 import com.tsurugidb.blob_relay.proto.BlobRelayCommon;
 import com.tsurugidb.blob_relay.proto.Streaming;
 import com.tsurugidb.tsubakuro.exception.ResponseTimeoutException;
+import com.tsurugidb.tsubakuro.exception.ServerException;
+import com.tsurugidb.tsubakuro.util.FutureResponse;
 
 /**
  * BlobRelayStreaming is a class that provides methods for streaming Blob data using gRPC.
  */
 public class BlobRelayStreaming implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(BlobRelayStreaming.class);
+
     private static final long CLOSE_TIMEOUT = 1_000; // 1 second
     private final BlobRelayStreamingGrpc.BlobRelayStreamingStub stub;
     private final long chunkSize;
@@ -87,18 +95,16 @@ public class BlobRelayStreaming implements Closeable {
      * Sends Blob data to the gRPC server.
      * @param meta the metadata associated with the Blob data to send
      * @param input the InputStream containing the Blob data to send
-     * @param timeout the timeout in milliseconds for the gRPC call
-     * @param timeUnit the TimeUnit for the timeout
      * @return a reference to the Blob data that was sent
      * @throws IOException if an I/O error occurs while reading the InputStream
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
-    public BlobRelayCommon.BlobReference put(Streaming.PutStreamingRequest.Metadata meta, InputStream input, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
+    public FutureResponse<BlobRelayCommon.BlobReference> put(Streaming.PutStreamingRequest.Metadata meta, InputStream input) throws IOException, InterruptedException {
         final AtomicReference<BlobRelayCommon.BlobReference> reference = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         final AtomicReference<CountDownLatch> countDownLatch = new AtomicReference<>(new CountDownLatch(1));
 
-        final class PutResponseObserver implements StreamObserver<Streaming.PutStreamingResponse> {
+        final StreamObserver<Streaming.PutStreamingRequest> requestObserver = stub.put(new StreamObserver<Streaming.PutStreamingResponse>() {
             @Override
             public void onNext(Streaming.PutStreamingResponse response) {
                 reference.set(response.getBlob());
@@ -122,11 +128,7 @@ public class BlobRelayStreaming implements Closeable {
             public void onCompleted() {
                 countDownLatch.get().countDown();
             }
-        }
-
-        StreamObserver<Streaming.PutStreamingRequest> requestObserver = (timeout > 0 && timeUnit != null)
-            ? stub.withDeadlineAfter(timeout, timeUnit).put(new PutResponseObserver())
-            : stub.put(new PutResponseObserver());
+        });
 
         try {
             requestObserver.onNext(Streaming.PutStreamingRequest.newBuilder()
@@ -140,34 +142,59 @@ public class BlobRelayStreaming implements Closeable {
                                         .setChunk(com.google.protobuf.ByteString.copyFrom(buffer, 0, bytesRead))
                                         .build());
             }
+            // Mark the end of requests
+            requestObserver.onCompleted();
         } catch (RuntimeException e) {
             // Cancel RPC
             requestObserver.onError(e);
             throw e;
         }
-        // Mark the end of requests
-        requestObserver.onCompleted();
 
-        countDownLatch.get().await();
-        checkException(error.get());
-        return reference.get();
-    }
-
-    /**
-     * Sends Blob data to the gRPC server.
-     * @param meta the metadata associated with the Blob data to send
-     * @param input the InputStream containing the Blob data to send
-     * @return a reference to the Blob data that was sent
-     * @throws IOException if an I/O error occurs while reading the InputStream
-     * @throws InterruptedException if the thread is interrupted while waiting for the response
-     */
-    public BlobRelayCommon.BlobReference put(Streaming.PutStreamingRequest.Metadata meta, InputStream input) throws IOException, InterruptedException {
-        return put(meta, input, 0, null);
+        return new FutureResponse<BlobRelayCommon.BlobReference>() {
+            @Override
+            public BlobRelayCommon.BlobReference get() throws IOException, InterruptedException, ServerException {
+                try {
+                    return get(0, null);
+                } catch (TimeoutException e) {
+                    throw new AssertionError("Unexpected TimeoutException", e);
+                }
+            }
+            @Override
+            public BlobRelayCommon.BlobReference get(long timeout, TimeUnit timeUnit) throws IOException, InterruptedException, ServerException, TimeoutException {
+                if (timeout < 0) {
+                    throw new IllegalArgumentException("timeout must be non-negative: " + timeout);
+                }
+                CountDownLatch latch = countDownLatch.get();
+                if (timeout > 0 && timeUnit != null) {
+                    if (!latch.await(timeout, timeUnit)) {
+                        throw new TimeoutException("Timeout while waiting for response after " + timeout + " " + timeUnit);
+                    }
+                } else {
+                    latch.await();
+                }
+                checkException(error.get());
+                return reference.get();
+            }
+            @Override
+            public boolean isDone() {
+                return countDownLatch.get().getCount() == 0;
+            }
+            @Override
+            public void close() {
+                if (!isDone()) {
+                    LOG.error("Warning: FutureResponse was closed before completion, cancelling the RPC");
+                    requestObserver.onError(new IOException("FutureResponse was closed before completion"));
+                }
+            }
+        };
     }
 
     private static class CustomPipedInputStream extends PipedInputStream {
-        AtomicReference<Throwable> exceptionRef = new AtomicReference<>(null);
+        private final AtomicReference<Throwable> exceptionRef = new AtomicReference<>(null);
+        private final AtomicBoolean pipedOutputStreamIsClosed = new AtomicBoolean(false);
         private final PipedOutputStream pipedOutputStream;
+        long timeout = 0;
+        TimeUnit timeUnit = null;
 
         CustomPipedInputStream(PipedOutputStream pipedOutputStream, int pipeSize) throws IOException {
             super(pipedOutputStream, pipeSize);
@@ -180,23 +207,20 @@ public class BlobRelayStreaming implements Closeable {
 
         @Override
         public int read() throws IOException {
-            int rv = super.read();
-            checkException();
-            return rv;
+            waitforData();
+            return super.read();
         }
 
         @Override
         public int read(byte[] b) throws IOException {
-            int rv = super.read(b);
-            checkException();
-            return rv;
+            waitforData();
+            return super.read(b);
         }
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            int rv = super.read(b, off, len);
-            checkException();
-            return rv;
+            waitforData();
+            return super.read(b, off, len);
         }
 
         @Override
@@ -206,6 +230,42 @@ public class BlobRelayStreaming implements Closeable {
             } finally {
                 super.close();
                 pipedOutputStream.close();
+            }
+        }
+
+        synchronized void setTimeout(long t, TimeUnit u) {
+            timeout = t;
+            timeUnit = u;
+        }
+
+        private void waitforData() throws IOException {
+            synchronized (this) {
+                while (available() < 1 && !pipedOutputStreamIsClosed.get()) {
+                    try {
+                        if (timeout > 0 && timeUnit != null) {
+                            long timeoutMillis = timeUnit.toMillis(timeout);
+                            long startTime = System.currentTimeMillis();
+                            wait(timeoutMillis);
+                            long elapsed = System.currentTimeMillis() - startTime;
+                            if (elapsed >= timeoutMillis) {
+                                throw new ResponseTimeoutException("Timeout while waiting for data after " + timeout + " " + timeUnit);
+                            }
+                        } else {
+                            wait();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Thread was interrupted while waiting for data", e);
+                    }
+                }
+                checkException();
+            }
+        }
+
+        void notifyDataAvailable(boolean closed) {
+            synchronized (this) {
+                pipedOutputStreamIsClosed.set(closed);
+                notifyAll();
             }
         }
 
@@ -226,66 +286,142 @@ public class BlobRelayStreaming implements Closeable {
     /**
      * Receives Blob data from the gRPC server.
      * @param request the request containing the reference to the Blob data to retrieve
-     * @param timeout the timeout in milliseconds for the gRPC call
-     * @param timeUnit the TimeUnit for the timeout
      * @return an InputStream to read the Blob data
      * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
      * @throws InterruptedException if the thread is interrupted while waiting for the response
      */
-    public InputStream get(Streaming.GetStreamingRequest request, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
-        return getInternal(request, null, timeout, timeUnit);
-    }
-
-    /**
-     * Receives Blob data from the gRPC server.
-     * @param request the request containing the reference to the Blob data to retrieve
-     * @return an InputStream to read the Blob data
-     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
-     * @throws InterruptedException if the thread is interrupted while waiting for the response
-     */
-    public InputStream get(Streaming.GetStreamingRequest request) throws IOException, InterruptedException {
-        return get(request, 0, null);
-    }
-
-    /**
-     * Receives Blob data from the gRPC server.
-     * @param request the request containing the reference to the Blob data to retrieve
-     * @param path the Path to write the Blob data to
-     * @param timeout the timeout in milliseconds for the gRPC call
-     * @param timeUnit the TimeUnit for the timeout
-     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
-     * @throws InterruptedException if the thread is interrupted while waiting for the response
-     */
-    public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path, long timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
-        getInternal(request, path, timeout, timeUnit);
-    }
-
-    /**
-     * Receives Blob data from the gRPC server.
-     * @param request the request containing the reference to the Blob data to retrieve
-     * @param path the Path to write the Blob data to
-     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the file at path
-     * @throws InterruptedException if the thread is interrupted while waiting for the response
-     */
-    public void get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path path) throws IOException, InterruptedException {
-        get(request, path, 0, null);
-    }
-
-    private InputStream getInternal(@Nonnull Streaming.GetStreamingRequest request, @Nullable Path path, long timeout, @Nullable TimeUnit timeUnit) throws IOException, InterruptedException {
-        final boolean writeToFile = (path != null);
+    public FutureResponse<InputStream> get(Streaming.GetStreamingRequest request) throws IOException, InterruptedException {
         final AtomicReference<Throwable> error = new AtomicReference<>();
-        final AtomicReference<CustomPipedInputStream> inputStream = new AtomicReference<>(null);
-        final AtomicReference<CountDownLatch> countDownLatch = new AtomicReference<>(writeToFile ? new CountDownLatch(1) : null);
+        final PipedOutputStream pipedOutputStream = new PipedOutputStream();
+        final CustomPipedInputStream pipedInputStream = new CustomPipedInputStream(pipedOutputStream, (int) chunkSize);
 
-        final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
-            final OutputStream outputStream;
-
+        stub.get(request, new StreamObserver<Streaming.GetStreamingResponse>() {
             Streaming.GetStreamingResponse.Metadata metadata = null;
             long totalBytes = 0;
 
-            GetResponseObserver(OutputStream outputStream) {
-                this.outputStream = outputStream;
+            @Override
+            public void onNext(Streaming.GetStreamingResponse response) {
+                switch (response.getPayloadCase()) {
+                    case CHUNK:
+                        try {
+                            var chunk = response.getChunk();
+                            totalBytes += chunk.size();
+                            var bytes = chunk.toByteArray();
+                            int offset = 0;
+                            while (offset < bytes.length) {
+                                int length = (int) Math.min(chunkSize, bytes.length - offset);
+                                pipedOutputStream.write(bytes, offset, length);
+                                pipedOutputStream.flush();
+                                pipedInputStream.notifyDataAvailable(false);
+                                offset += length;
+                            }
+                        } catch (IOException e) {
+                            // Handle the exception
+                            LOG.error("Error while writing chunk data to pipedOutputStream: {}", e.getMessage(), e);
+                            setError(e);
+                        }
+                        break;
+                    case METADATA:
+                        metadata = response.getMetadata();
+                        break;
+                    case PAYLOAD_NOT_SET:
+                        // Handle the case where no payload is set
+                        break;
+                }
             }
+            private synchronized void setError(Throwable e) {
+                var err = error.get();
+                if (err != null) {
+                    err.addSuppressed(e);
+                } else {
+                    err = e;
+                }
+                pipedInputStream.setException(err);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // Handle the error
+                try {
+                    boolean isDeadlineExceeded = false;
+                    if (t instanceof StatusRuntimeException) {
+                        StatusRuntimeException statusEx = (StatusRuntimeException) t;
+                        if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                            isDeadlineExceeded = true;
+                        }
+                    }
+                    setError(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
+                } finally {
+                    try {
+                        pipedOutputStream.close();
+                        pipedInputStream.notifyDataAvailable(true);
+                    } catch (IOException e) {
+                        // Handle the exception
+                        setError(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onCompleted() {
+                // Handle the completion
+                try {
+                    pipedOutputStream.close();
+                    pipedInputStream.notifyDataAvailable(true);
+                } catch (IOException e) {
+                    // Handle the exception
+                    setError(e);
+                }
+                // check the metadata and total bytes
+                if (metadata == null) {
+                    setError(new IOException("Failed to retrieve blob data, as metadata is missing"));
+                } else {
+                    if (metadata.getBlobSizeOptCase() == Streaming.GetStreamingResponse.Metadata.BlobSizeOptCase.BLOB_SIZE) {
+                        if (totalBytes != metadata.getBlobSize()) {
+                            setError(new IOException("Failed to retrieve blob data, as expected size " + metadata.getBlobSize() + " bytes does not match received size " + totalBytes + " bytes"));
+                        }
+                    }
+                }
+            }
+        });
+
+        return new FutureResponse<InputStream>() {
+            @Override
+            public InputStream get() {
+                return get(0, null);
+            }
+            @Override
+            public InputStream get(long timeout, TimeUnit timeUnit) {
+                pipedInputStream.setTimeout(timeout, timeUnit);
+                return pipedInputStream;
+            }
+            @Override
+            public boolean isDone() {
+                return true;
+            }
+            @Override
+            public void close() throws IOException {
+                // do nothing, as the pipedInputStream will be closed by the onCompleted or onError callback
+            }
+        };
+    }
+
+    /**
+     * Receives Blob data from the gRPC server.
+     * @param request the request containing the reference to the Blob data to retrieve
+     * @param destination the Path to write the Blob data to
+     * @return a FutureResponse that completes when the Blob data has been fully received and written to the OutputStream
+     * @throws IOException if an I/O error occurs while reading the BLOB data / while writing to the OutputStream
+     * @throws InterruptedException if the thread is interrupted while waiting for the response
+     */
+    public FutureResponse<Void> get(@Nonnull Streaming.GetStreamingRequest request, @Nonnull Path destination) throws IOException, InterruptedException {
+        final OutputStream outputStream = Files.newOutputStream(destination);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicReference<CountDownLatch> countDownLatch = new AtomicReference<>(new CountDownLatch(1));
+
+        final class GetResponseObserver implements StreamObserver<Streaming.GetStreamingResponse> {
+            Streaming.GetStreamingResponse.Metadata metadata = null;
+            long totalBytes = 0;
 
             @Override
             public void onNext(Streaming.GetStreamingResponse response) {
@@ -316,50 +452,31 @@ public class BlobRelayStreaming implements Closeable {
                 } else {
                     err = e;
                 }
-                if (writeToFile) {
-                    error.set(err);
-                } else {
-                    if (inputStream.get() != null) {
-                        inputStream.get().setException(err);
-                    }
-                }
+                error.set(err);
             }
 
             @Override
             public void onError(Throwable t) {
                 // Handle the error
-                try {
-                    boolean isDeadlineExceeded = false;
-                    if (t instanceof StatusRuntimeException) {
-                        StatusRuntimeException statusEx = (StatusRuntimeException) t;
-                        if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
-                            isDeadlineExceeded = true;
-                        }
-                    }
-                    setError(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
-                } finally {
-                    try {
-                        outputStream.close();
-                    } catch (IOException e) {
-                        // Handle the exception
-                        setError(e);
-                    }
-                    if (writeToFile) {
-                        countDownLatch.get().countDown();
+                boolean isDeadlineExceeded = false;
+                if (t instanceof StatusRuntimeException) {
+                    StatusRuntimeException statusEx = (StatusRuntimeException) t;
+                    if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                        isDeadlineExceeded = true;
                     }
                 }
+                setError(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
             }
 
             @Override
             public void onCompleted() {
-                if (writeToFile) {
+                // Handle the completion
+                if (countDownLatch.get().getCount() > 0) {
                     countDownLatch.get().countDown();
                 }
-                // Handle the completion
                 try {
                     outputStream.close();
                 } catch (IOException e) {
-                    // Handle the exception
                     setError(e);
                 }
                 // check the metadata and total bytes
@@ -374,29 +491,50 @@ public class BlobRelayStreaming implements Closeable {
                 }
             }
         }
+        final GetResponseObserver responseObserver = new GetResponseObserver();
+        stub.get(request, responseObserver);
 
-        GetResponseObserver responseObserver;
-        if (writeToFile) {
-            responseObserver = new GetResponseObserver(new FileOutputStream(path.toFile()));
-        } else {
-            PipedOutputStream pipedOutputStream = new PipedOutputStream();
-            responseObserver = new GetResponseObserver(pipedOutputStream);
-            inputStream.set(new CustomPipedInputStream(pipedOutputStream, (int) chunkSize));
-        }
-
-        if (timeout > 0 && timeUnit != null) {
-            stub.withDeadlineAfter(timeout, timeUnit).get(request, responseObserver);
-        } else {
-            stub.get(request, responseObserver);
-        }
-
-        if (writeToFile) {
-            countDownLatch.get().await();
-            checkException(error.get());
-            return null;
-        } else {
-            return inputStream.get();
-        }
+        return new FutureResponse<Void>() {
+            @Override
+            public Void get() throws IOException, InterruptedException, ServerException {
+                try {
+                    return get(0, null);
+                } catch (TimeoutException e) {
+                    throw new AssertionError("Unexpected TimeoutException", e);
+                }
+            }
+            @Override
+            public Void get(long timeout, TimeUnit timeUnit) throws IOException, InterruptedException, ServerException, TimeoutException {
+                if (timeout < 0) {
+                    throw new IllegalArgumentException("timeout must be non-negative: " + timeout);
+                }
+                CountDownLatch latch = countDownLatch.get();
+                if (timeout > 0 && timeUnit != null) {
+                    if (!latch.await(timeout, timeUnit)) {
+                        responseObserver.setError(new ResponseTimeoutException("Timeout while waiting for response after " + timeout + " " + timeUnit));
+                        throw new TimeoutException("Timeout while waiting for response after " + timeout + " " + timeUnit);
+                    }
+                } else {
+                    latch.await();
+                }
+                checkException(error.get());
+                return null;
+            }
+            @Override
+            public boolean isDone() {
+                return countDownLatch.get().getCount() == 0;
+            }
+            @Override
+            public void close() throws IOException {
+                if (error.get() != null) {
+                    Files.deleteIfExists(destination);
+                }
+                if (!isDone()) {
+                    LOG.error("Warning: FutureResponse was closed before completion, cancelling the RPC");
+                    responseObserver.onCompleted();
+                }
+            }
+        };
     }
     private static void checkException(Throwable e) throws IOException {
         if (e != null) {

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -386,12 +386,15 @@ public class BlobRelayStreaming implements Closeable {
         });
 
         return new FutureResponse<InputStream>() {
+            volatile boolean gotten = false;
+
             @Override
             public InputStream get() {
                 return get(0, null);
             }
             @Override
-            public InputStream get(long timeout, TimeUnit timeUnit) {
+            public synchronized InputStream get(long timeout, TimeUnit timeUnit) {
+                gotten = true;
                 pipedInputStream.setTimeout(timeout, timeUnit);
                 return pipedInputStream;
             }
@@ -400,7 +403,11 @@ public class BlobRelayStreaming implements Closeable {
                 return true;
             }
             @Override
-            public void close() throws IOException {
+            public synchronized void close() throws IOException {
+                if (!gotten) {
+                    LOG.error("Warning: FutureResponse was closed before get() was called, cancelling the RPC");
+                    pipedInputStream.setException(new IOException("FutureResponse was closed before get() was called"));
+                }
                 // do nothing, as the pipedInputStream will be closed by the onCompleted or onError callback
             }
         };
@@ -466,19 +473,23 @@ public class BlobRelayStreaming implements Closeable {
                     }
                 }
                 setError(isDeadlineExceeded ? new ResponseTimeoutException(t) : t);
+                    try {
+                        outputStream.close();
+                    } catch (IOException e) {
+                        setError(e);
+                    }
+                    countDownLatch.get().countDown();
             }
 
             @Override
             public void onCompleted() {
                 // Handle the completion
-                if (countDownLatch.get().getCount() > 0) {
-                    countDownLatch.get().countDown();
-                }
                 try {
                     outputStream.close();
                 } catch (IOException e) {
                     setError(e);
                 }
+                countDownLatch.get().countDown();
                 // check the metadata and total bytes
                 if (metadata == null) {
                     setError(new IOException("Failed to retrieve blob data, as metadata is missing"));

--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Assumptions;
@@ -44,7 +46,7 @@ import com.tsurugidb.tsubakuro.relay.server.BlobRelayStreamingServer;
 class BlobRelayStreamingTest {
     private static final Logger LOG = LoggerFactory.getLogger(BlobRelayStreamingTest.class);
     
-    private static final int TEST_DATA_SIZE = 1024 * 10;
+    private static final int TEST_DATA_SIZE = 1024 * 2 + 123; // 2KB + 123 bytes to ensure multiple chunks are tested
 
     private BlobRelayStreamingServer server;
     private BlobRelayStreaming client;
@@ -65,7 +67,6 @@ class BlobRelayStreamingTest {
     @AfterEach
     void teardown() throws IOException, InterruptedException {
         server.stop();
-        server.blockUntilShutdown();
         if (client != null) {
             client.close();
         }
@@ -90,7 +91,8 @@ class BlobRelayStreamingTest {
         var result = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
                                                                             .setSessionId(128)
                                                                       .build(),
-                                new ByteArrayInputStream(data));
+                                new ByteArrayInputStream(data))
+                           .get();     ;
 
         // verify received data and response
         assertNotNull(result);
@@ -107,13 +109,14 @@ class BlobRelayStreamingTest {
         var data = new byte[TEST_DATA_SIZE];
         new Random().nextBytes(data);
 
-        assertThrows(ResponseTimeoutException.class, () -> {
-            client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
-                                                                .setSessionId(128)
-                                                             .build(),
-                       new ByteArrayInputStream(data),
-                       1, TimeUnit.SECONDS);
-        });
+        try (var future = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
+                                                                                .setSessionId(128)
+                                                                            .build(),
+                                     new ByteArrayInputStream(data))) {
+            assertThrows(TimeoutException.class, () -> {
+                future.get(1, TimeUnit.SECONDS);
+            });
+        }
     }
 
     @Test
@@ -133,7 +136,7 @@ class BlobRelayStreamingTest {
                                                             .build());
 
         // test get() method
-        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
+        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);  // Use a smaller chunk size to test multiple chunks
         var inputStream = client.get(Streaming.GetStreamingRequest.newBuilder()
                                                     .setTransactionId(789)
                                                     .setBlob(BlobRelayCommon.BlobReference.newBuilder()
@@ -141,7 +144,7 @@ class BlobRelayStreamingTest {
                                                         .setObjectId(23)
                                                         .setTag(45))
                                                 .build());
-        var data = inputStream.readAllBytes();
+        var data = inputStream.get().readAllBytes();
 
         // verify received data
         assertArrayEquals(buffer, data);
@@ -160,8 +163,8 @@ class BlobRelayStreamingTest {
                                                     .setStorageId(1)
                                                     .setObjectId(23)
                                                     .setTag(45))
-                                            .build(),
-                                            1, TimeUnit.SECONDS);
+                                            .build())
+                                .get(1, TimeUnit.SECONDS);
         Throwable exception = assertThrows(ResponseTimeoutException.class, () -> {
             inputStream.readAllBytes();
         });
@@ -169,23 +172,24 @@ class BlobRelayStreamingTest {
 
     @Test
     void getTimeoutWithPath(@TempDir Path dir) throws Exception {
-        Path file = dir.resolve("blog");
+        Path file = dir.resolve("blob_data.bin");
 
         server.injectFault(BlobRelayStreamingServer.FaultType.NoResponse);
 
         // test get() method
         client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
-
-        assertThrows(ResponseTimeoutException.class, () -> {
-            client.get(Streaming.GetStreamingRequest.newBuilder()
-                                    .setTransactionId(789)
-                                    .setBlob(BlobRelayCommon.BlobReference.newBuilder()
-                                        .setStorageId(1)
-                                        .setObjectId(23)
-                                        .setTag(45))
-                                .build(),
-                                file,
-                                1, TimeUnit.SECONDS);
-        });
+        try (var future = client.get(Streaming.GetStreamingRequest.newBuilder()
+                                .setTransactionId(789)
+                                .setBlob(BlobRelayCommon.BlobReference.newBuilder()
+                                    .setStorageId(1)
+                                    .setObjectId(23)
+                                    .setTag(45))
+                            .build(),
+                            file)) {
+            var e =assertThrows(TimeoutException.class, () -> {
+                future.get(1, TimeUnit.SECONDS);
+            });
+        }
+        assertTrue(Files.notExists(file), "File should not be created on timeout");
     }
 }

--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -88,11 +88,11 @@ class BlobRelayStreamingTest {
         client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);
         var data = new byte[TEST_DATA_SIZE];
         new Random().nextBytes(data);
-        var result = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
+        var future = client.put(Streaming.PutStreamingRequest.Metadata.newBuilder()
                                                                             .setSessionId(128)
                                                                       .build(),
-                                new ByteArrayInputStream(data))
-                           .get();     ;
+                                new ByteArrayInputStream(data));
+        var result = future.get();
 
         // verify received data and response
         assertNotNull(result);

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -83,6 +83,7 @@ public class BlobRelayStreamingServer {
     public void stop() throws InterruptedException {
         if (server != null) {
             try {
+                server.shutdown();
                 if (!server.awaitTermination(1, TimeUnit.SECONDS)) {
                     server.shutdownNow();
                 }

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -82,7 +82,14 @@ public class BlobRelayStreamingServer {
 
     public void stop() throws InterruptedException {
         if (server != null) {
-            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
+            try {
+                if (!server.awaitTermination(1, TimeUnit.SECONDS)) {
+                    server.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                server.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -136,8 +136,23 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                     return reference.get().isDone();
                 }
                 @Override
-                public void close() {
-                    // do nothing, the caller is responsible for closing the input stream and the BlobRelayStreaming will be closed when this client is closed
+                public void close() throws IOException {
+                    var r = reference.get();
+                    if (r != null) {
+                        try {
+                            r.close();
+                        } catch (ServerException e) {
+                            LOG.error("Failed to close put FutureResponse", e);
+                            throw new IOException("Failed to close put FutureResponse", e);
+                        } catch (InterruptedException e) {
+                            LOG.error("Failed to close put FutureResponse", e);
+                            Thread.currentThread().interrupt();
+                            throw new IOException("Failed to close put FutureResponse", e);
+                        } catch (IOException e) {
+                            LOG.error("Failed to close put FutureResponse", e);
+                            throw e;
+                        }
+                    }
                 }
             };
         } catch (IOException | InterruptedException e) {
@@ -231,16 +246,11 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                 }
             }
             public Reader get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
-                var inputStreamFuture = openInputStream(contextId, ref);
-                try {
-                    return new InputStreamReader(inputStreamFuture.get(timeout, unit), StandardCharsets.UTF_8);
-                } catch (IOException | InterruptedException | ServerException | TimeoutException e) {
-                    throw new BlobException("Failed to open Reader", e);
-                }
+                return new InputStreamReader(openInputStream(contextId, ref).get(timeout, unit), StandardCharsets.UTF_8);
             }
             @Override
             public boolean isDone() {
-                return false; // We cannot determine if the Reader is ready until we try to get it
+                return true;
             }
             @Override
             public void close() {

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -16,7 +16,6 @@
 package com.tsurugidb.tsubakuro.common.impl;
 
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -28,6 +27,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.Optional;
@@ -90,41 +90,32 @@ public class LargeObjectClientRelay implements LargeObjectClient {
         return chunkSize;
     }
 
-    private abstract class FutureResponseImpl<T> implements FutureResponse<T> {
-        protected volatile boolean done = false;
-
-        @Override
-        public T get() throws IOException, InterruptedException, ServerException {
-            try {
-                return get(0, null);
-            } catch (TimeoutException e) {
-                throw new AssertionError("Unexpected TimeoutException", e);
-            }
-        }
-        @Override
-        public boolean isDone() {
-            return done;
-        }
-        @Override
-        public void close() {
-        }
-    }
-
     @Override
     public FutureResponse<LargeObjectInfo> upload(InputStream source) throws BlobException {
-        return upload(source,
-                      Streaming.PutStreamingRequest.Metadata.newBuilder()
-                            .setApiVersion(API_VERSION)
-                            .setSessionId(sessionId)
-                            .build());
+        return internalUpload(Streaming.PutStreamingRequest.Metadata.newBuilder()
+                                .setApiVersion(API_VERSION)
+                                .setSessionId(sessionId)
+                                .build(),
+                              source);
     }
-    private FutureResponse<LargeObjectInfo> upload(InputStream source, Streaming.PutStreamingRequest.Metadata meta) throws BlobException {
-        return new FutureResponseImpl<LargeObjectInfo>() {
-            @Override
-            public LargeObjectInfo get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
-                try {
-                    openBlobRelayStreaming();
-                    var ref = blobRelayStreaming.put(meta, source, timeout, unit);
+    private FutureResponse<LargeObjectInfo> internalUpload(Streaming.PutStreamingRequest.Metadata meta, InputStream source) throws BlobException {
+        final AtomicReference<FutureResponse<BlobRelayCommon.BlobReference>> reference = new AtomicReference<>();
+
+        try {
+            openBlobRelayStreaming();
+            reference.set(blobRelayStreaming.put(meta, source));
+            return new FutureResponse<LargeObjectInfo>() {
+                @Override
+                public LargeObjectInfo get() throws IOException, InterruptedException, ServerException {
+                    try {
+                        return get(0, null);
+                    } catch (TimeoutException e) {
+                        throw new AssertionError("Unexpected timeout", e);
+                    }
+                }
+                @Override
+                public LargeObjectInfo get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
+                    var ref = reference.get().get(timeout, unit);
                     return new LargeObjectInfo() {
                         @Override
                         public InfoType getInfoType() {
@@ -139,11 +130,19 @@ public class LargeObjectClientRelay implements LargeObjectClient {
                             throw new IllegalStateException("LargeObjectInfo type is BLOB_RELAY_REFERENCE, server path is not available");
                         }
                     };
-                } finally {
-                    done = true;
                 }
-            }
-        };
+                @Override
+                public boolean isDone() {
+                    return reference.get().isDone();
+                }
+                @Override
+                public void close() {
+                    // do nothing, the caller is responsible for closing the input stream and the BlobRelayStreaming will be closed when this client is closed
+                }
+            };
+        } catch (IOException | InterruptedException e) {
+            throw new BlobException("Failed to open BlobRelayStreaming", e);
+        }
     }
     private synchronized void openBlobRelayStreaming() throws IOException {
         if (blobRelayStreaming == null) {
@@ -188,12 +187,12 @@ public class LargeObjectClientRelay implements LargeObjectClient {
     @Override
     public FutureResponse<LargeObjectInfo> upload(Path source) throws BlobException {
         try {
-            return upload(Files.newInputStream(source),
-                          Streaming.PutStreamingRequest.Metadata.newBuilder()
-                                .setApiVersion(API_VERSION)
-                                .setSessionId(sessionId)
-                                .setBlobSize(Files.size(source))
-                                .build());
+            return internalUpload(Streaming.PutStreamingRequest.Metadata.newBuilder()
+                                    .setApiVersion(API_VERSION)
+                                    .setSessionId(sessionId)
+                                    .setBlobSize(Files.size(source))
+                                    .build(),
+                                  Files.newInputStream(source));
         } catch (IOException e) {
             throw new BlobException("Failed to read from Path", e);
         }
@@ -201,17 +200,12 @@ public class LargeObjectClientRelay implements LargeObjectClient {
 
     @Override
     public FutureResponse<InputStream> openInputStream(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
-        return new FutureResponseImpl<InputStream>() {
-            @Override
-            public InputStream get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
-                try {
-                    openBlobRelayStreaming();
-                    return blobRelayStreaming.get(newGetStreamingRequest(contextId, ref),  timeout, unit);
-                } finally {
-                    done = true;
-                }
-            }
-        };
+        try {
+            openBlobRelayStreaming();
+            return blobRelayStreaming.get(newGetStreamingRequest(contextId, ref));
+        } catch (IOException | InterruptedException e) {
+            throw new BlobException("Failed to open InputStream", e);
+        }
     }
     private Streaming.GetStreamingRequest newGetStreamingRequest(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) {
         return Streaming.GetStreamingRequest.newBuilder()
@@ -227,15 +221,30 @@ public class LargeObjectClientRelay implements LargeObjectClient {
 
     @Override
     public FutureResponse<Reader> openReader(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref) throws BlobException {
-        return new FutureResponseImpl<Reader>() {
+        return new FutureResponse<Reader>() {
             @Override
+            public Reader get() throws IOException, InterruptedException, ServerException {
+                 try {
+                    return get(0, null);
+                } catch (TimeoutException e) {
+                    throw new AssertionError("Unexpected timeout", e);
+                }
+            }
             public Reader get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
                 var inputStreamFuture = openInputStream(contextId, ref);
                 try {
                     return new InputStreamReader(inputStreamFuture.get(timeout, unit), StandardCharsets.UTF_8);
-                } finally {
-                    done = true;
+                } catch (IOException | InterruptedException | ServerException | TimeoutException e) {
+                    throw new BlobException("Failed to open Reader", e);
                 }
+            }
+            @Override
+            public boolean isDone() {
+                return false; // We cannot determine if the Reader is ready until we try to get it
+            }
+            @Override
+            public void close() {
+                // No resources to close in this implementation, the caller is responsible for closing the Reader and the underlying InputStream
             }
         };
     }
@@ -256,19 +265,23 @@ public class LargeObjectClientRelay implements LargeObjectClient {
 
     @Override
     public FutureResponse<Void> copyTo(@Nonnull ContextId contextId, @Nonnull LargeObjectReference ref, @Nonnull Path destination) throws BlobException {
-        return new FutureResponseImpl<Void>() {
-            @Override
-            public Void get(long timeout, TimeUnit unit) throws IOException, InterruptedException, ServerException, TimeoutException {
-                var request = newGetStreamingRequest(contextId, ref);
-                try (FileOutputStream fileOutputStream = new FileOutputStream(destination.toFile())) {
-                    openBlobRelayStreaming();
-                    blobRelayStreaming.get(request, destination, timeout, unit);
-                    return null;
-                } finally {
-                    done = true;
+        try {
+            openBlobRelayStreaming();
+            try {
+                if (Files.exists(destination)) {
+                    throw new BlobException("Destination file already exists: " + destination);
                 }
+            } catch (IOException e) {
+                throw new BlobException("Failed to prepare destination path: " + destination, e);
             }
-        };
+            try {
+                return blobRelayStreaming.get(newGetStreamingRequest(contextId, ref), destination);
+            } catch (IOException | InterruptedException e) {
+                throw new BlobException("Failed to copy to destination", e);
+            }
+        } catch (IOException e) {
+            throw new BlobException("Failed to copy to destination", e);
+        }
     }
 
     @Override

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
@@ -16,12 +16,10 @@
 package com.tsurugidb.tsubakuro.common.impl;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-// import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-// import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -29,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.Reader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -54,7 +53,7 @@ import com.tsurugidb.tsubakuro.common.LargeObjectReference;
 import com.tsurugidb.tsubakuro.relay.server.BlobRelayStreamingServer;
 
 class LargeObjectClientRelayTest {
-    private static final int SERVER_PORT = 65521;
+    private static final int CHUNK_SIZE = 1024;
 
     private LargeObjectClient client = null;
 
@@ -105,7 +104,7 @@ class LargeObjectClientRelayTest {
             server = new BlobRelayStreamingServer();
             server.start();
 
-            client = new LargeObjectClientRelay("123", "localhost:" + server.getPort(), false, 1024 * 1024);
+            client = new LargeObjectClientRelay("123", "localhost:" + server.getPort(), false, CHUNK_SIZE);
         } catch (IOException e) {
             System.err.println(e);
             e.printStackTrace();
@@ -207,8 +206,10 @@ class LargeObjectClientRelayTest {
                                     .setBlobSize(data.length))
                                 .build());
 
-        var inputStream = client.openInputStream(contextId, lobReference).await();
-
+        InputStream inputStream = null;
+        try (var future = client.openInputStream(contextId, lobReference)) {
+            inputStream = future.await();
+        }
         assertNotNull(inputStream);
         var obtainedData = inputStream.readAllBytes();
         assertArrayEquals(data, obtainedData);
@@ -222,20 +223,25 @@ class LargeObjectClientRelayTest {
 
     @Test
     void openInputStream_largeBlob() throws Exception {
-        byte[] largeData = new byte[4096];
+        byte[] largeData = new byte[CHUNK_SIZE * 2 + 123]; // 2 chunks + 123 bytes
         for (int i = 0; i < largeData.length; i++) {
             largeData[i] = (byte) ('a' + (i % 26));
         }
 
-        server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
-                                .setChunk(com.google.protobuf.ByteString.copyFrom(largeData))
-                                .build());
+        int offset = 0;
+        while (offset < largeData.length) {
+            int chunkSize = Math.min(CHUNK_SIZE, largeData.length - offset);
+            server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
+                                    .setChunk(com.google.protobuf.ByteString.copyFrom(largeData, offset, chunkSize))
+                                    .build());
+            offset += chunkSize;
+        }
         server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
                                 .setMetadata(Streaming.GetStreamingResponse.Metadata.newBuilder()
                                     .setBlobSize(largeData.length))
                                 .build());
 
-        assertTimeoutPreemptively(Duration.ofSeconds(3), () -> {
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
             var inputStream = client.openInputStream(contextId, lobReference).await();
             assertNotNull(inputStream);
             var obtainedData = inputStream.readAllBytes();

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
@@ -206,10 +206,10 @@ class LargeObjectClientRelayTest {
                                     .setBlobSize(data.length))
                                 .build());
 
-        InputStream inputStream = null;
-        try (var future = client.openInputStream(contextId, lobReference)) {
-            inputStream = future.await();
-        }
+        var future = client.openInputStream(contextId, lobReference);
+        InputStream inputStream = future.await();
+        future.close();
+
         assertNotNull(inputStream);
         var obtainedData = inputStream.readAllBytes();
         assertArrayEquals(data, obtainedData);


### PR DESCRIPTION
This PR updates the relay-based large object streaming implementation to return `FutureResponse` objects for gRPC streaming operations (upload/download), and adjusts related session-layer wrappers and tests to reflect the new asynchronous/cancellable behavior.

**Changes:**
- Refactor `BlobRelayStreaming` `put()`/`get()` APIs to return `FutureResponse` and update timeout behavior to be handled via the returned future/stream reads.
- Update `LargeObjectClientRelay` to delegate to the new relay client futures for upload/download/copy operations.
- Update relay/session tests and test fixtures to exercise multi-chunk streaming and revised timeout/cancellation patterns.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401