### PR TITLE
add a test that continues processing even if a timeout occurs

### DIFF
--- a/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
+++ b/modules/relay/src/test/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreamingTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
@@ -135,19 +136,21 @@ class BlobRelayStreamingTest {
                                                                 .build())
                                                             .build());
 
-        // test get() method
-        client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);  // Use a smaller chunk size to test multiple chunks
-        var inputStream = client.get(Streaming.GetStreamingRequest.newBuilder()
-                                                    .setTransactionId(789)
-                                                    .setBlob(BlobRelayCommon.BlobReference.newBuilder()
-                                                        .setStorageId(1)
-                                                        .setObjectId(23)
-                                                        .setTag(45))
-                                                .build());
-        var data = inputStream.get().readAllBytes();
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            // test get() method
+            client = new BlobRelayStreaming("localhost:" + server.getPort(), false, 1024);  // Use a smaller chunk size to test multiple chunks
+            var inputStream = client.get(Streaming.GetStreamingRequest.newBuilder()
+                                                        .setTransactionId(789)
+                                                        .setBlob(BlobRelayCommon.BlobReference.newBuilder()
+                                                            .setStorageId(1)
+                                                            .setObjectId(23)
+                                                            .setTag(45))
+                                                    .build());
+            var data = inputStream.get().readAllBytes();
 
-        // verify received data
-        assertArrayEquals(buffer, data);
+            // verify received data
+            assertArrayEquals(buffer, data);
+        });
     }
 
     @Test

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -110,6 +110,7 @@ public class BlobRelayStreamingServer {
     public enum FaultType {
         NoFault,
         NoResponse,
+        PauseResponse,
     }
 
     public void injectFault(FaultType faultType) {
@@ -149,6 +150,7 @@ public class BlobRelayStreamingServer {
             return new StreamObserver<Streaming.PutStreamingRequest>() {
                 @Override
                 public void onNext(Streaming.PutStreamingRequest request) {
+                    pauseResponse();
                     switch (request.getPayloadCase()) {
                         case METADATA:
                             if (request.getMetadata().getBlobSizeOptCase() == Streaming.PutStreamingRequest.Metadata.BlobSizeOptCase.BLOB_SIZE) {
@@ -184,6 +186,7 @@ public class BlobRelayStreamingServer {
 
                 @Override
                 public void onCompleted() {
+                    pauseResponse();
                     if (receivedSizeValid.get()) {
                         if (receivedData.get().length != receivedSize.get()) {
                             throw new RuntimeException("Received data size does not match the expected size: " + receivedSize.get() + " != " + receivedData.get().length);
@@ -213,12 +216,22 @@ public class BlobRelayStreamingServer {
             }
             blobReference = request.getBlob();
             while (!getResponses.isEmpty()) {
+                pauseResponse();
                 var response = getResponses.poll();
                 responseObserver.onNext(response);
             }
+            pauseResponse(); // Ensure the client has time to receive all responses before completion
             responseObserver.onCompleted();
         }
-
+        private void pauseResponse() {
+            if (injectedFault == FaultType.PauseResponse) {
+                try {
+                    Thread.sleep(1000); // Simulate a delay in response
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
         // register responses for testing
         void addPutResponse(Streaming.PutStreamingResponse response) {
             putResponses.offer(response);

--- a/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
+++ b/modules/relay/src/testFixtures/java/com/tsurugidb/tsubakuro/relay/server/BlobRelayStreamingServer.java
@@ -220,13 +220,13 @@ public class BlobRelayStreamingServer {
                 var response = getResponses.poll();
                 responseObserver.onNext(response);
             }
-            pauseResponse(); // Ensure the client has time to receive all responses before completion
+            pauseResponse(); // If PauseResponse fault is injected, delay completion to provoke client-side timeouts
             responseObserver.onCompleted();
         }
         private void pauseResponse() {
             if (injectedFault == FaultType.PauseResponse) {
                 try {
-                    Thread.sleep(1000); // Simulate a delay in response
+                    TimeUnit.SECONDS.sleep(1); // Simulate a delay in response
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +51,7 @@ import com.tsurugidb.tsubakuro.common.Session;
 import com.tsurugidb.tsubakuro.common.LargeObjectClient;
 import com.tsurugidb.tsubakuro.common.LargeObjectInfo;
 import com.tsurugidb.tsubakuro.common.LargeObjectReference;
+import com.tsurugidb.tsubakuro.exception.ResponseTimeoutException;
 import com.tsurugidb.tsubakuro.relay.server.BlobRelayStreamingServer;
 
 class LargeObjectClientRelayTest {
@@ -206,19 +208,21 @@ class LargeObjectClientRelayTest {
                                     .setBlobSize(data.length))
                                 .build());
 
-        var future = client.openInputStream(contextId, lobReference);
-        InputStream inputStream = future.await();
-        future.close();
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            var future = client.openInputStream(contextId, lobReference);
+            InputStream inputStream = future.await();
+            future.close();
 
-        assertNotNull(inputStream);
-        var obtainedData = inputStream.readAllBytes();
-        assertArrayEquals(data, obtainedData);
+            assertNotNull(inputStream);
+            var obtainedData = inputStream.readAllBytes();
+            assertArrayEquals(data, obtainedData);
 
-        var lobReference = server.getBlobReference();
-        assertEquals(1, lobReference.getStorageId());
-        assertEquals(12345, lobReference.getObjectId());
-        assertEquals(678, lobReference.getTag());
-        assertFalse(server.hasRemaining());
+            var lobReference = server.getBlobReference();
+            assertEquals(1, lobReference.getStorageId());
+            assertEquals(12345, lobReference.getObjectId());
+            assertEquals(678, lobReference.getTag());
+            assertFalse(server.hasRemaining());
+        });
     }
 
     @Test
@@ -251,6 +255,56 @@ class LargeObjectClientRelayTest {
     }
 
     @Test
+    void openInputStream_largeBlob_timeout() throws Exception {
+        server.injectFault(BlobRelayStreamingServer.FaultType.PauseResponse);
+
+        byte[] largeData = new byte[CHUNK_SIZE * 2 + 123]; // 2 chunks + 123 bytes
+        for (int i = 0; i < largeData.length; i++) {
+            largeData[i] = (byte) ('a' + (i % 26));
+        }
+
+        int offset = 0;
+        while (offset < largeData.length) {
+            int chunkSize = Math.min(CHUNK_SIZE, largeData.length - offset);
+            server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
+                                    .setChunk(com.google.protobuf.ByteString.copyFrom(largeData, offset, chunkSize))
+                                    .build());
+            offset += chunkSize;
+        }
+        server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
+                                .setMetadata(Streaming.GetStreamingResponse.Metadata.newBuilder()
+                                    .setBlobSize(largeData.length))
+                                .build());
+
+        assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
+            byte[] receivedData = new byte[CHUNK_SIZE * 3];
+            var inputStream = client.openInputStream(contextId, lobReference).await(500, TimeUnit.MILLISECONDS);
+            assertNotNull(inputStream);
+
+            boolean timeoutOccurred = false;
+            int received = 0;
+            while (true) {
+                try {
+                    int bytesRead = inputStream.read(receivedData, received, receivedData.length - received);
+                    if (bytesRead == -1) {
+                        break;
+                    }
+                    received += bytesRead;
+                } catch (ResponseTimeoutException e) {
+                    timeoutOccurred = true;
+                    continue; // Expected timeout, continue reading remaining data
+                } catch (IOException e) {
+                    fail("Expected a ResponseTimeoutException, but got IOException: " + e.getMessage());
+                }
+            }
+            assertTrue(timeoutOccurred);
+            assertArrayEquals(largeData, Arrays.copyOf(receivedData, received));
+        });
+
+        assertFalse(server.hasRemaining());
+    }
+
+    @Test
     void openReader() throws Exception {
         // for blob relay service
         server.addGetResponse(Streaming.GetStreamingResponse.newBuilder()
@@ -260,24 +314,24 @@ class LargeObjectClientRelayTest {
                                 .setMetadata(Streaming.GetStreamingResponse.Metadata.newBuilder()
                                     .setBlobSize(data.length))
                                 .build());
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            var reader = client.openReader(contextId, lobReference).await();
 
-        var reader = client.openReader(contextId, lobReference).await();
+            assertNotNull(reader);
+            char[] obtainedData = new char[data.length];
+            reader.read(obtainedData);
+            for (int i = 0; i < data.length; i++) {
+                assertEquals(data[i], obtainedData[i]);
+            }
+            assertEquals(-1, reader.read());
 
-        assertNotNull(reader);
-        char[] obtainedData = new char[data.length];
-        reader.read(obtainedData);
-        for (int i = 0; i < data.length; i++) {
-            assertEquals(data[i], obtainedData[i]);
-        }
-        assertEquals(-1, reader.read());
-
-        var lobReference = server.getBlobReference();
-        assertEquals(1, lobReference.getStorageId());
-        assertEquals(12345, lobReference.getObjectId());
-        assertEquals(678, lobReference.getTag());
-        assertFalse(server.hasRemaining());
+            var lobReference = server.getBlobReference();
+            assertEquals(1, lobReference.getStorageId());
+            assertEquals(12345, lobReference.getObjectId());
+            assertEquals(678, lobReference.getTag());
+            assertFalse(server.hasRemaining());
+        });
     }
-
     
     @Test
     void copyTo(@TempDir Path tempDir) throws Exception {
@@ -291,17 +345,18 @@ class LargeObjectClientRelayTest {
                                 .setMetadata(Streaming.GetStreamingResponse.Metadata.newBuilder()
                                     .setBlobSize(data.length))
                                 .build());
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            var reader = client.copyTo(contextId, lobReference, file).await();
 
-        var reader = client.copyTo(contextId, lobReference, file).await();
+            assertTrue(Files.exists(file));
+            var obtainedData = Files.readAllBytes(file);
+            assertArrayEquals(data, obtainedData);
 
-        assertTrue(Files.exists(file));
-        var obtainedData = Files.readAllBytes(file);
-        assertArrayEquals(data, obtainedData);
-
-        var lobReference = server.getBlobReference();
-        assertEquals(1, lobReference.getStorageId());
-        assertEquals(12345, lobReference.getObjectId());
-        assertEquals(678, lobReference.getTag());
-        assertFalse(server.hasRemaining());
+            var lobReference = server.getBlobReference();
+            assertEquals(1, lobReference.getStorageId());
+            assertEquals(12345, lobReference.getObjectId());
+            assertEquals(678, lobReference.getTag());
+            assertFalse(server.hasRemaining());
+        });
     }
 }

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelayTest.java
@@ -209,9 +209,10 @@ class LargeObjectClientRelayTest {
                                 .build());
 
         assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
-            var future = client.openInputStream(contextId, lobReference);
-            InputStream inputStream = future.await();
-            future.close();
+            InputStream inputStream = null;
+            try (var future = client.openInputStream(contextId, lobReference)) {
+                inputStream = future.await();
+            }
 
             assertNotNull(inputStream);
             var obtainedData = inputStream.readAllBytes();


### PR DESCRIPTION
This PR adds coverage to ensure large object streaming continues reading remaining data even when intermittent read timeouts occur, using a test fixture fault injection to simulate delayed server responses.

**Changes:**
- Wrap existing relay-related tests with `assertTimeoutPreemptively` to bound execution time and avoid hangs.
- Add a new `openInputStream_largeBlob_timeout` test that expects `ResponseTimeoutException` during reads but continues processing until completion.
- Extend the relay test fixture server with a new `PauseResponse` fault mode to introduce controlled response delays.

**Related issue** 
https://github.com/project-tsurugi/tsurugi-issues/issues/1401