### PR TITLE
fix the error message that appears when the blob relay service is una…

### DIFF
--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -590,7 +590,7 @@ public class BlobRelayStreaming implements Closeable {
             } else if (e instanceof StatusRuntimeException) {
                 StatusRuntimeException statusEx = (StatusRuntimeException) e;
                 if (statusEx.getStatus().getCode() == Status.Code.UNAVAILABLE) {
-                    throw new IOException("blob relay service is unavailable on " + endpoint, e);
+                    throw new IOException("Blob relay service is unavailable on " + endpoint, e);
                 } else if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
                     throw new ResponseTimeoutException(e);
                 }

--- a/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
+++ b/modules/relay/src/main/java/com/tsurugidb/tsubakuro/relay/client/BlobRelayStreaming.java
@@ -61,6 +61,7 @@ public class BlobRelayStreaming implements Closeable {
     private final BlobRelayStreamingGrpc.BlobRelayStreamingStub stub;
     private final long chunkSize;
     private final ManagedChannel channel;
+    private final String endpoint;
 
     /**
      * Creates a new BlobRelayStreaming.
@@ -70,6 +71,7 @@ public class BlobRelayStreaming implements Closeable {
      */
     public BlobRelayStreaming(@Nonnull String endpoint, boolean secure, long chunkSize) {
         this.chunkSize = validateChunkSize(chunkSize);
+        this.endpoint = endpoint;
         this.channel = Grpc.newChannelBuilder(endpoint, secure ? TlsChannelCredentials.create() : InsecureChannelCredentials.create()).build();
         this.stub = BlobRelayStreamingGrpc.newStub(channel);
     }
@@ -581,10 +583,17 @@ public class BlobRelayStreaming implements Closeable {
             }
         };
     }
-    private static void checkException(Throwable e) throws IOException {
+    private void checkException(Throwable e) throws IOException {
         if (e != null) {
             if (e instanceof IOException) {
                 throw (IOException) e;
+            } else if (e instanceof StatusRuntimeException) {
+                StatusRuntimeException statusEx = (StatusRuntimeException) e;
+                if (statusEx.getStatus().getCode() == Status.Code.UNAVAILABLE) {
+                    throw new IOException("blob relay service is unavailable on " + endpoint, e);
+                } else if (statusEx.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+                    throw new ResponseTimeoutException(e);
+                }
             } else if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Thread was interrupted", e);


### PR DESCRIPTION
Improves the client-side error reporting for Blob Relay gRPC streaming operations by mapping specific gRPC status codes (notably `UNAVAILABLE`) into clearer `IOException` messages that include the configured endpoint, so callers get a more actionable failure when the Blob Relay service is down/unreachable.

**Changes:**
- Store the gRPC endpoint on `BlobRelayStreaming` instances for later use in error reporting.
- Enhance exception translation to detect `Status.Code.UNAVAILABLE` and throw a targeted `IOException` message (and map `DEADLINE_EXCEEDED` to `ResponseTimeoutException`).

**Related issue++
https://github.com/project-tsurugi/tsurugi-issues/issues/1401#issuecomment-4646894258