### PR TITLE
add SessionBuilder.withBlobRelayEndpoint(String)

### DIFF
--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
@@ -172,6 +172,16 @@ public final class SessionBuilder {
      * @param endpoint the blob relay endpoint
      * @return this
      */
+    public SessionBuilder withBlobRelayEndpoint(@Nonnull String endpoint) {
+        Objects.requireNonNull(endpoint);
+        return withBlobRelayEndpoint(URI.create(endpoint));
+    }
+
+    /**
+     * Sets the blob relay endpoint for BLOB transfer.
+     * @param endpoint the blob relay endpoint
+     * @return this
+     */
     public SessionBuilder withBlobRelayEndpoint(@Nonnull URI endpoint) {
         Objects.requireNonNull(endpoint);
         this.blobRelayEndpoint = endpoint;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/SessionBuilder.java
@@ -170,6 +170,7 @@ public final class SessionBuilder {
     /**
      * Sets the blob relay endpoint for BLOB transfer.
      * @param endpoint the blob relay endpoint
+     * @throws IllegalArgumentException if the endpoint string is not a valid URI
      * @return this
      */
     public SessionBuilder withBlobRelayEndpoint(@Nonnull String endpoint) {

--- a/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/SessionBuilderTest.java
+++ b/modules/session/src/test/java/com/tsurugidb/tsubakuro/common/SessionBuilderTest.java
@@ -137,4 +137,16 @@ class SessionBuilderTest {
             }
         }
     }
+
+    @Test
+    void withBlobRelayEndpointInvalidURI() throws Exception {
+        var wire = new MockWire();
+        var builder = SessionBuilder.connect(new Connector() {
+            @Override
+            public FutureResponse<Wire> connect(ClientInformation clientInformation) throws IOException {
+                return FutureResponse.wrap(Owner.of(wire));
+            }
+        });
+        assertThrows(IllegalArgumentException.class, () -> builder.withBlobRelayEndpoint(":/:/:/invalid-uri:/:/:/"));
+    }
 }


### PR DESCRIPTION
This PR adds a convenience overload to `SessionBuilder` to allow configuring the BLOB relay endpoint using a `String`, delegating to the existing `URI`-based API.

**Changes:**
- Added `SessionBuilder.withBlobRelayEndpoint(String)` which parses the string via `URI.create(...)` and delegates to `withBlobRelayEndpoint(URI)`.
- Added Javadoc for the new overload.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1401