### PR TITLE
since tag correction

### DIFF
--- a/docs/blob_relay_design_ja.md
+++ b/docs/blob_relay_design_ja.md
@@ -256,7 +256,7 @@ public interface LargeObjectReference {
  * (e.g. opening streams/readers, cache access, and copy operations)
  * in a single client abstraction.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public interface LargeObjectClient {
     /**

--- a/docs/internal/blob_relay_impl_ja.md
+++ b/docs/internal/blob_relay_impl_ja.md
@@ -245,7 +245,7 @@ public interface BlobTransferMedium {
      * @param reference the info of the uploaded CLOB
      * @return the created place-holder
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     public static SqlRequest.Parameter clobOf(@Nonnull String name, @Nonnull LargeObjectInfo reference) {
         // 実装
@@ -258,7 +258,7 @@ public interface BlobTransferMedium {
      * @param reference the info of the uploaded BLOB
      * @return the created place-holder
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     public static SqlRequest.Parameter blobOf(@Nonnull String name, @Nonnull LargeObjectInfo reference) {
             // 実装
@@ -307,7 +307,7 @@ public interface BlobInfo {
      * </p>
      * @return the BlobRelayReference of the LargeObject, or empty when the BLOB relay service is not used.
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     Optional<BlobRelayReference> getBlobRelayReference();
 }

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Wire.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/channel/common/connection/wire/Wire.java
@@ -166,7 +166,7 @@ public interface Wire extends ServerResource {
      * Returns the BlobTransferMedium that the LargeObjectClient uses.
      * @return the BlobTransferMedium
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     default BlobTransferMedium getBlobTransferMedium() {
         return null;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/BlobRelayReference.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/BlobRelayReference.java
@@ -20,7 +20,7 @@ import com.tsurugidb.sql.proto.SqlRequest;
 /**
  * A class that stores reference of the BLOB/CLOB uploaded.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public class BlobRelayReference {
     private final long storageId;

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/BlobTransferType.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/BlobTransferType.java
@@ -18,7 +18,7 @@ package com.tsurugidb.tsubakuro.common;
 /**
  * Blob transfer type used in the session.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public enum BlobTransferType {
     /**

--- a/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/ServerBlobInfo.java
+++ b/modules/common/src/main/java/com/tsurugidb/tsubakuro/common/ServerBlobInfo.java
@@ -18,7 +18,7 @@ package com.tsurugidb.tsubakuro.common;
 /**
  * An abstract super interface of BLOB data to send to Tsurugi server.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public class ServerBlobInfo {
     private final String channelName;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/BlobInfo.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/BlobInfo.java
@@ -62,7 +62,7 @@ public interface BlobInfo {
      * </p>
      * @return the server path of the LargeObject, or empty when the BLOB relay service is not used.
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     default Optional<String> getServerPath() {
         throw new UnsupportedOperationException();
@@ -75,7 +75,7 @@ public interface BlobInfo {
      * </p>
      * @return the BlobRelayReference of the LargeObject, or empty when the BLOB relay service is not used.
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     default Optional<BlobRelayReference> getBlobRelayReference() {
         throw new UnsupportedOperationException();

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectCache.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectCache.java
@@ -23,7 +23,7 @@ import com.tsurugidb.tsubakuro.util.ServerResource;
 /**
  * Represents large object cache.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public interface LargeObjectCache extends ServerResource {
 

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectClient.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectClient.java
@@ -31,7 +31,7 @@ import com.tsurugidb.tsubakuro.util.FutureResponse;
  * (e.g. opening streams/readers, cache access, and copy operations)
  * in a single client abstraction.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public interface LargeObjectClient extends Closeable {
     /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectInfo.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectInfo.java
@@ -21,13 +21,13 @@ package com.tsurugidb.tsubakuro.common;
   * If a prepared statement execution request is made, <code>LargeObjectInfo</code> becomes unavailable (behavior is undefined if used).
   * </p>
   *
-  * @since 1.11.0
+  * @since 1.16.0
   */
 public interface LargeObjectInfo {
     /**
      * The information type of uploaded large object.
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     enum InfoType {
           /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectReference.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/LargeObjectReference.java
@@ -18,7 +18,7 @@ package com.tsurugidb.tsubakuro.common;
 /**
  * An abstract super interface of large object references at Session layer.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public interface LargeObjectReference {
     /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java
@@ -251,7 +251,7 @@ public interface Session extends ServerResource {
      * @throws IOException if an error occurs while initializing the LargeObjectClient
      * @throws IllegalStateException if the session does not handle BLOBs
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     default LargeObjectClient getLargeObjectClient() throws IOException {
         throw new UnsupportedOperationException();
@@ -261,7 +261,7 @@ public interface Session extends ServerResource {
      * Returns the BlobTransferMedium that the LargeObjectClient uses.
      * @return the BlobTransferMedium
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     default BlobTransferMedium getBlobTransferMedium() {
         throw new UnsupportedOperationException();

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientPrivileged.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientPrivileged.java
@@ -60,7 +60,7 @@ import com.tsurugidb.tsubakuro.util.FutureResponse;
  * An implementation of {@link LargeObjectClient} that provides privileged access to the Large Object storage.
  * This client is used when the endpoint supports privileged access and the session is configured to use privileged transfer type.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public class LargeObjectClientPrivileged implements LargeObjectClient {
     /**

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientRelay.java
@@ -53,7 +53,7 @@ import com.tsurugidb.tsubakuro.util.FutureResponse;
  * An implementation of {@link LargeObjectClient} that provides privileged access to the Large Object storage.
  * This client is used when the endpoint supports privileged access and the session is configured to use privileged transfer type.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public class LargeObjectClientRelay implements LargeObjectClient {
     private static final long API_VERSION = 1;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectClientVoid.java
@@ -36,7 +36,7 @@ import com.tsurugidb.tsubakuro.util.FutureResponse;
  * (for example, {@code DOES_NOT_USE} / no medium).
  * All operations are unavailable and will throw {@link BlobException}.
  *
- * @since 1.11.0
+ * @since 1.16.0
  */
 public class LargeObjectClientVoid implements LargeObjectClient {
     static final String ERROR_MESSAGE = "BLOB functionality is unavailable in this session."; //$NON-NLS-1$

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectInfoImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/LargeObjectInfoImpl.java
@@ -22,7 +22,7 @@ import com.tsurugidb.tsubakuro.common.LargeObjectInfo;
 /**
   * A class representing the uploaded large object information.
   *
-  * @since 1.11.0
+  * @since 1.16.0
   */
 public class LargeObjectInfoImpl implements LargeObjectInfo {
     private final SqlRequest.ClientOnlyLargeObjectInfo largeObjectInfo;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/impl/SessionImpl.java
@@ -213,7 +213,7 @@ public class SessionImpl implements Session {
      * @deprecated use SessionImpl() after connect(wire)
      * @param wire the underlying wire
      */
-    @Deprecated
+    @Deprecated(since = "1.8.0")
     public SessionImpl(@Nonnull Wire wire) {
         Objects.requireNonNull(wire);
         this.wire = wire;

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/Parameters.java
@@ -377,7 +377,7 @@ public final class Parameters {
      * @param info the large object info
      * @return the created place-holder
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     public static SqlRequest.Parameter clobOf(@Nonnull String name, @Nonnull LargeObjectInfo info) {
         Objects.requireNonNull(name);
@@ -431,7 +431,7 @@ public final class Parameters {
      * @param info the large object info
      * @return the created place-holder
      *
-     * @since 1.11.0
+     * @since 1.16.0
      */
     public static SqlRequest.Parameter blobOf(@Nonnull String name, @Nonnull LargeObjectInfo info) {
         Objects.requireNonNull(name);

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/PreparedStatementImpl.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/impl/PreparedStatementImpl.java
@@ -90,7 +90,7 @@ public class PreparedStatementImpl implements PreparedStatement {
      * @param handle the handle of the PreparedStatement
      * @deprecated as tests now always use disposer.
      */
-    @Deprecated
+    @Deprecated(since = "1.11.0")
     public PreparedStatementImpl(SqlCommon.PreparedStatement handle) {
         this(handle, null, null, null, null);
     }

--- a/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BlobException.java
+++ b/modules/session/src/main/java/com/tsurugidb/tsubakuro/sql/io/BlobException.java
@@ -21,7 +21,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * An exception which occurs if BLOB handling fails.
  * @deprecated This class is deprecated since it will be substituted by {@link com.tsurugidb.tsubakuro.common.exception.BlobException} in the new implementation.
  */
-@Deprecated
+@Deprecated(since = "1.16.0")
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class BlobException extends com.tsurugidb.tsubakuro.common.exception.BlobException {
     /**


### PR DESCRIPTION
As the only incorrect `since` tags were the ones added this time, they were corrected.