### PR TITLE
ci: add ubuntu-26.04 to build matrix os

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
     runs-on: ${{ matrix.os }}
     permissions:
       checks: write


### PR DESCRIPTION
CI workflow improvements:
* Added `ubuntu-26.04` to the build matrix in `.github/workflows/ci-build.yml` to ensure compatibility with the latest Ubuntu release.