### PR TITLE
Release 1.17.0 snapshot

### DIFF
--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.tsurugidb.tsubakuro'
-version = '1.16.0'
+version = '1.17.0-SNAPSHOT'
 
 java {
     toolchain {

--- a/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
+++ b/buildSrc/src/main/groovy/tsubakuro.java-base.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.tsurugidb.tsubakuro'
-version = '1.16.0-SNAPSHOT'
+version = '1.16.0'
 
 java {
     toolchain {

--- a/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/ServerStreamLink.java
+++ b/modules/stream/src/test/java/com/tsurugidb/tsubakuro/channel/stream/ServerStreamLink.java
@@ -171,14 +171,8 @@ public class ServerStreamLink {
             } else {
                 bytes = null;
             }
-        } catch (EOFException e) {  // imply session close
-            if (socket != null) {
-                socket.close();
-                socket = null;
-            }
-            return false;
-        } catch (SocketException e) {
-            socket = null;
+        } catch (EOFException | SocketException e) {
+            close();
             return false;
         }
         return true;
@@ -194,7 +188,7 @@ public class ServerStreamLink {
         return bytes;
     }
 
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (socket != null) {
             socket.close();
             socket = null;


### PR DESCRIPTION
Bumps the project snapshot version to align the build metadata with the upcoming 1.17.0 development cycle.

**Changes:**
- Update the Gradle buildSrc base version from `1.16.0-SNAPSHOT` to `1.17.0-SNAPSHOT`.

**Related issue**
https://github.com/project-tsurugi/tsurugi-issues/issues/1506